### PR TITLE
feat(zcql): added zcql olap query support

### DIFF
--- a/packages/zcql/src/index.ts
+++ b/packages/zcql/src/index.ts
@@ -35,31 +35,18 @@ export class ZCQL {
 	}
 
 	/**
-	 * Executes a ZCQL (Zoho Catalyst Query Language) query to fetch data from the datastore.
-	 * @param sql - The ZCQL query string to execute.
-	 *              Example: `'SELECT * FROM Users WHERE status = 'active''`.
-	 *
-	 * @throws CatalystZCQLError - Thrown if the query string is empty or invalid.
-	 * @throws CatalystApiError - Thrown if the query execution fails or returns an invalid response.
-	 *
-	 * @example
-	 *  ```js
-	 * const query = 'SELECT * FROM Users WHERE status = 'active'';
-	 * try {
-	 *      const data = await executeZCQLQuery(query);
-	 *      console.log(data); // Logs table data matching the query.
-	 * } catch (error) {
-	 *      console.error('Error executing query:', error);
-	 * }
-	 * ```
+	 * Implementation function to execute the ZCQL query.
+	 * @param query The ZCQL query string to execute.
+	 * @param olap To enable OLAP mode for the query.
 	 * @returns A promise resolving to an array of table values, each conforming to the `ICatalystTableData` interface.
 	 */
-	async executeZCQLQuery(query: string): Promise<Array<ICatalystTableData>> {
+	async #executeQuery(query: string, olap = false): Promise<Array<ICatalystTableData>> {
 		await wrapValidatorsWithPromise(() => {
 			isNonEmptyString(query, 'query', true);
 		}, CatalystZCQLError);
 		const postData = {
-			query
+			query,
+			OLAP: olap
 		};
 		const request: IRequestConfig = {
 			method: REQ_METHOD.post,
@@ -76,5 +63,53 @@ export class ZCQL {
 		};
 		const resp = await this.requester.send(request);
 		return resp.data.data as Array<ICatalystTableData>;
+	}
+
+	/**
+	 * Executes a ZCQL (Zoho Catalyst Query Language) query to fetch data from the datastore.
+	 * @param query - The ZCQL query string to execute.
+	 *              Example: `'SELECT * FROM Users WHERE status = 'active''`.
+	 *
+	 * @throws CatalystZCQLError - Thrown if the query string is empty or invalid.
+	 * @throws CatalystApiError - Thrown if the query execution fails or returns an invalid response.
+	 *
+	 * @example
+	 *  ```js
+	 * const query = "SELECT * FROM Users WHERE status = 'active'";
+	 * try {
+	 *      const data = await executeZCQLQuery(query);
+	 *      console.log(data); // Logs table data matching the query.
+	 * } catch (error) {
+	 *      console.error('Error executing query:', error);
+	 * }
+	 * ```
+	 * @returns A promise resolving to an array of table values, each conforming to the `ICatalystTableData` interface.
+	 */
+	async executeQuery(query: string): Promise<Array<ICatalystTableData>> {
+		return this.#executeQuery(query);
+	}
+
+	/**
+	 * Executes a ZCQL (Zoho Catalyst Query Language) query to fetch data from the datastore in OLAP mode.
+	 * @param query - The ZCQL query string to execute.
+	 *              Example: `'SELECT * FROM Users WHERE status = 'active''`.
+	 *
+	 * @throws CatalystZCQLError - Thrown if the query string is empty or invalid.
+	 * @throws CatalystApiError - Thrown if the query execution fails or returns an invalid response.
+	 *
+	 * @example
+	 *  ```js
+	 * const query = "SELECT * FROM Users WHERE status = 'active'";
+	 * try {
+	 *      const data = await executeZCQLQuery(query);
+	 *      console.log(data); // Logs table data matching the query.
+	 * } catch (error) {
+	 *      console.error('Error executing query:', error);
+	 * }
+	 * ```
+	 * @returns A promise resolving to an array of table values, each conforming to the `ICatalystTableData` interface.
+	 */
+	async executeOLAPQuery(query: string): Promise<Array<ICatalystTableData>> {
+		return this.#executeQuery(query, true);
 	}
 }

--- a/packages/zcql/tests/index.test.ts
+++ b/packages/zcql/tests/index.test.ts
@@ -36,9 +36,16 @@ describe('zcql', () => {
 	app.setRequestResponseMap(resdata);
 
 	it('execute ZCQL Query', async () => {
-		await expect(zcql.executeZCQLQuery('execute query')).resolves.toStrictEqual(
+		await expect(zcql.executeQuery('execute query')).resolves.toStrictEqual(
 			resdata['/query'].POST.data.data
 		);
-		await expect(zcql.executeZCQLQuery('')).rejects.toThrow();
+		await expect(zcql.executeQuery('')).rejects.toThrow();
+	});
+
+	it('execute ZCQL Query in OLAP mode', async () => {
+		await expect(zcql.executeOLAPQuery('execute query')).resolves.toStrictEqual(
+			resdata['/query'].POST.data.data
+		);
+		await expect(zcql.executeOLAPQuery('')).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
### Issue
Not an Issue

### Description
This implementation add the ZCQL OLAP query support to the SDK with the `ZCQL.executeOLAPQuery` method.

Additionally, the `ZCQL.executeExecuteQuery` method is removed and replace it with `ZCQL.executeQuery` method.

### Testing
Unit test written. Tested against the Catalyst APIs in development.

### Additional context
Add any other context about the PR here.

### Checklist
- [x] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [x] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
