### PR TITLE
feat(browser_grid): added browser grid support

### DIFF
--- a/packages/smartbrowz/src/browser-grid.ts
+++ b/packages/smartbrowz/src/browser-grid.ts
@@ -1,0 +1,112 @@
+import { Handler, IRequestConfig, ResponseType } from '@zcatalyst/transport';
+import {
+	CatalystService,
+	CONSTANTS,
+	isNonEmptyString,
+	wrapValidatorsWithPromise
+} from '@zcatalyst/utils';
+
+import { CatalystSmartbrowzError } from './utils/error';
+import { IBrowserGridDetails, IBrowserGridNode } from './utils/interfaces';
+
+const { REQ_METHOD, CREDENTIAL_USER } = CONSTANTS;
+
+/**
+ * Provides admin-only APIs to manage SmartBrowz Browser Grids.
+ */
+export class BrowserGrid {
+	#requester: Handler;
+	constructor({ requester }: { requester: Handler }) {
+		this.#requester = requester;
+	}
+
+	/**
+	 * Retrieves the list of all Browser Grids present in the project.
+	 * @returns A promise that resolves to Array<IBrowserGridDetails>.
+	 * @example
+	 * ```ts
+	 * const grids = await smartbrowz.browserGrid().getGrid();
+	 * ```
+	 */
+	async getGrid(): Promise<Array<IBrowserGridDetails>>;
+	/**
+	 * Retrieves the details of a specific Browser Grid.
+	 * @param gridId - The id or name of the Browser Grid.
+	 * @returns A promise that resolves to IBrowserGridDetails.
+	 * @throws {CatalystSmartbrowzError} when `gridId` is not a valid non-empty string.
+	 * @example
+	 * ```ts
+	 * const grid = await smartbrowz.browserGrid().getGrid('testGrid');
+	 * ```
+	 */
+	async getGrid(gridId: string): Promise<IBrowserGridDetails>;
+	async getGrid(gridId?: string): Promise<IBrowserGridDetails | Array<IBrowserGridDetails>> {
+		if (gridId !== undefined) {
+			await wrapValidatorsWithPromise(() => {
+				isNonEmptyString(gridId, 'grid_id', true);
+			}, CatalystSmartbrowzError);
+		}
+		const request: IRequestConfig = {
+			method: REQ_METHOD.get,
+			path: `/browser-grid${gridId ? '/' + gridId : ''}`,
+			expecting: ResponseType.JSON,
+			service: CatalystService.SMARTBROWZ,
+			track: true,
+			user: CREDENTIAL_USER.admin
+		};
+		const resp = await this.#requester.send(request);
+		return resp.data.data as IBrowserGridDetails | Array<IBrowserGridDetails>;
+	}
+
+	/**
+	 * Retrieves the live node statistics of a Browser Grid.
+	 * @param gridId - The id or name of the Browser Grid.
+	 * @returns A promise that resolves to IBrowserGridNode.
+	 * @throws {CatalystSmartbrowzError} when `gridId` is not a valid non-empty string.
+	 * @example
+	 * ```ts
+	 * const nodes = await smartbrowz.browserGrid().getGridNodes('testGrid');
+	 * ```
+	 */
+	async getGridNodes(gridId: string): Promise<IBrowserGridNode> {
+		await wrapValidatorsWithPromise(() => {
+			isNonEmptyString(gridId, 'grid_id', true);
+		}, CatalystSmartbrowzError);
+		const request: IRequestConfig = {
+			method: REQ_METHOD.get,
+			path: `/browser-grid/${gridId}/stats?data_to_fetch=live_stats`,
+			expecting: ResponseType.JSON,
+			service: CatalystService.SMARTBROWZ,
+			track: true,
+			user: CREDENTIAL_USER.admin
+		};
+		const resp = await this.#requester.send(request);
+		return resp.data.data as IBrowserGridNode;
+	}
+
+	/**
+	 * Stops all the running nodes in a Browser Grid.
+	 * @param gridId - The id or name of the Browser Grid.
+	 * @returns A promise that resolves once the Browser Grid nodes are stopped.
+	 * @throws {CatalystSmartbrowzError} when `gridId` is not a valid non-empty string.
+	 * @example
+	 * ```ts
+	 * await smartbrowz.browserGrid().stopGrid('testGrid');
+	 * ```
+	 */
+	async stopGrid(gridId: string): Promise<void> {
+		await wrapValidatorsWithPromise(() => {
+			isNonEmptyString(gridId, 'grid_id', true);
+		}, CatalystSmartbrowzError);
+		const request: IRequestConfig = {
+			method: REQ_METHOD.post,
+			path: `/browser-grid/${gridId}/stop`,
+			expecting: ResponseType.JSON,
+			service: CatalystService.SMARTBROWZ,
+			track: true,
+			user: CREDENTIAL_USER.admin
+		};
+		const resp = await this.#requester.send(request);
+		return resp.data.data;
+	}
+}

--- a/packages/smartbrowz/src/browser-grid.ts
+++ b/packages/smartbrowz/src/browser-grid.ts
@@ -106,7 +106,6 @@ export class BrowserGrid {
 			track: true,
 			user: CREDENTIAL_USER.admin
 		};
-		const resp = await this.#requester.send(request);
-		return resp.data.data;
+		await this.#requester.send(request);
 	}
 }

--- a/packages/smartbrowz/src/index.ts
+++ b/packages/smartbrowz/src/index.ts
@@ -18,6 +18,7 @@ import { Readable } from 'stream';
 
 import pkg from '../package.json';
 const { version } = pkg;
+import { BrowserGrid } from './browser-grid';
 import { Dataverse } from './dataverse';
 import { CatalystSmartbrowzError } from './utils/error';
 import {
@@ -38,9 +39,11 @@ type ICatalystSmartbrowzTemplateOptions = ICatalystSmartbrowzTemplate &
 export class Smartbrowz implements Component {
 	readonly requester: Handler;
 	readonly #dataverse: Dataverse;
+	readonly #browserGrid: BrowserGrid;
 	constructor(app?: unknown) {
 		this.requester = new Handler(app, this);
 		this.#dataverse = new Dataverse({ requester: this.requester });
+		this.#browserGrid = new BrowserGrid({ requester: this.requester });
 	}
 
 	/**
@@ -226,5 +229,17 @@ export class Smartbrowz implements Component {
 		Dataverse['getSimilarCompanies']
 	> {
 		return this.#dataverse.getSimilarCompanies({ leadName, websiteUrl });
+	}
+
+	/**
+	 * Provides admin-only access to SmartBrowz Browser Grid management APIs.
+	 * @returns The BrowserGrid instance.
+	 * @example
+	 * ```ts
+	 * const grids = await smartbrowz.browserGrid().getGrid();
+	 * ```
+	 */
+	browserGrid(): BrowserGrid {
+		return this.#browserGrid;
 	}
 }

--- a/packages/smartbrowz/src/utils/interfaces.ts
+++ b/packages/smartbrowz/src/utils/interfaces.ts
@@ -101,3 +101,20 @@ export interface IDataverseTechStack {
 	website_status: string;
 	technographic_data: Record<string, string>;
 }
+
+export interface IBrowserGridDetails {
+	browser_version: Record<string, string>;
+	config_type: number;
+	endpoint_type: number;
+	id: string;
+	max_nodes_count: number;
+	max_session_count: number;
+	memory: number;
+	name: string;
+}
+
+export interface IBrowserGridNode {
+	node_count: number;
+	session_count: number;
+	session_queue_size: number;
+}

--- a/packages/smartbrowz/tests/browser-grid.test.ts
+++ b/packages/smartbrowz/tests/browser-grid.test.ts
@@ -1,0 +1,32 @@
+import { Smartbrowz } from '../src';
+
+const { responses } = require('../../../tests/api-responses.js');
+
+describe('testing smartbrowz browser grid', () => {
+	const smartbrowz: Smartbrowz = new Smartbrowz();
+
+	it('browser grid get all grids', async () => {
+		await expect(smartbrowz.browserGrid().getGrid()).resolves.toStrictEqual(
+			responses['/browser-grid'].GET.data.data
+		);
+	});
+
+	it('browser grid get grid by id', async () => {
+		await expect(smartbrowz.browserGrid().getGrid('testGrid')).resolves.toStrictEqual(
+			responses['/browser-grid/testGrid'].GET.data.data
+		);
+		await expect(smartbrowz.browserGrid().getGrid('')).rejects.toThrowError();
+	});
+
+	it('browser grid get grid nodes', async () => {
+		await expect(smartbrowz.browserGrid().getGridNodes('testGrid')).resolves.toStrictEqual(
+			responses['/browser-grid/testGrid/stats?data_to_fetch=live_stats'].GET.data.data
+		);
+		await expect(smartbrowz.browserGrid().getGridNodes('')).rejects.toThrowError();
+	});
+
+	it('browser grid stop grid', async () => {
+		await expect(smartbrowz.browserGrid().stopGrid('testGrid')).resolves.toBeUndefined();
+		await expect(smartbrowz.browserGrid().stopGrid('')).rejects.toThrowError();
+	});
+});

--- a/tests/api-responses.js
+++ b/tests/api-responses.js
@@ -1058,6 +1058,68 @@ exports.responses = {
 		}
 	},
 
+	// Smartbrowz - Browser Grid
+	'/browser-grid': {
+		GET: {
+			statusCode: 200,
+			data: {
+				status: 'success',
+				data: [
+					{
+						id: '1234',
+						name: 'testGrid',
+						browser_version: { chrome: '120.0' },
+						config_type: 1,
+						endpoint_type: 1,
+						max_nodes_count: 5,
+						max_session_count: 10,
+						memory: 512
+					}
+				]
+			}
+		}
+	},
+	'/browser-grid/testGrid': {
+		GET: {
+			statusCode: 200,
+			data: {
+				status: 'success',
+				data: {
+					id: '1234',
+					name: 'testGrid',
+					browser_version: { chrome: '120.0' },
+					config_type: 1,
+					endpoint_type: 1,
+					max_nodes_count: 5,
+					max_session_count: 10,
+					memory: 512
+				}
+			}
+		}
+	},
+	'/browser-grid/testGrid/stats?data_to_fetch=live_stats': {
+		GET: {
+			statusCode: 200,
+			data: {
+				status: 'success',
+				data: {
+					node_count: 3,
+					session_count: 2,
+					session_queue_size: 0
+				}
+			}
+		}
+	},
+	'/browser-grid/testGrid/stop': {
+		POST: {
+			statusCode: 200,
+			data: {
+				status: 'success',
+				data: undefined
+			}
+		}
+	},
+
 	// Smartbrowz - Dataverse
 	'/dataverse/lead-enrichment': {
 		POST: {


### PR DESCRIPTION
Adds Browser Grid management APIs to the `@zcatalyst/smartbrowz` package.

### Changes
- **`packages/smartbrowz/src/browser-grid.ts`** (new): Introduces `BrowserGrid` class with:
  - `getGrid()` / `getGrid(gridId)` — list all Browser Grids or fetch details of a specific grid
  - `getGridNodes(gridId)` — fetch live node statistics for a grid
  - `stopGrid(gridId)` — stop all running nodes in a grid
- **`packages/smartbrowz/src/index.ts`**: Wires up `BrowserGrid` into `Smartbrowz`, exposing it via a new `browserGrid()` accessor.
- **`packages/smartbrowz/src/utils/interfaces.ts`**: Adds `IBrowserGridDetails` and `IBrowserGridNode` interfaces.
- **`packages/smartbrowz/tests/browser-grid.test.ts`** (new) and **`tests/api-responses.js`**: Unit tests and mock API responses for the new endpoints.

### Checklist
- [x] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [x] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
