### PR TITLE
fix(connector): default header inclusion in external endpoint issue

### DIFF
--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -22,6 +22,7 @@
     "build:types:downlevel": "rimraf dist-types/ts3.4 && downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo || exit 0",
     "typedoc": "npx typedoc",
+    "test": "jest --config ./jest.config.js tests/oauth-security.test.ts --coverage=false",
     "lint": "eslint -c ../../eslint.config.mjs \"src/**/*.ts\"",
     "format": "prettier  --ignore-path ../.prettierignore --write \"{src, test}/*.ts\""
   },

--- a/packages/connector/src/connection.ts
+++ b/packages/connector/src/connection.ts
@@ -92,11 +92,17 @@ export class Connector {
 				`The ${fieldName} must be a valid, absolute URL.`
 			);
 		}
-		const parsedUrl = new URL(url);
+		let parsedUrl: URL;
+		try {
+			parsedUrl = new URL(url);
+		} catch {
+			throw new CatalystConnectorError(
+				'INVALID_OAUTH_URL',
+				`The ${fieldName} must be a valid, absolute URL.`
+			);
+		}
 		const isLoopbackHost =
-			parsedUrl.hostname === 'localhost' ||
-			parsedUrl.hostname === '127.0.0.1' ||
-			parsedUrl.hostname === '::1';
+			parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1';
 		if (parsedUrl.protocol !== 'https:' && !isLoopbackHost) {
 			throw new CatalystConnectorError(
 				'INSECURE_OAUTH_URL',

--- a/packages/connector/src/connection.ts
+++ b/packages/connector/src/connection.ts
@@ -8,6 +8,7 @@ import {
 	ICatalystGResponse,
 	isNonEmptyString,
 	isNonNullObject,
+	isURL,
 	ObjectHasProperties,
 	wrapValidatorsWithPromise
 } from '@zcatalyst/utils';
@@ -75,6 +76,36 @@ export class Connector {
 	private get _connectorName(): string {
 		return 'ZC_CONN_' + this.connectorName;
 	}
+
+	/**
+	 * Validates that a configured OAuth endpoint is a well-formed, HTTPS URL.
+	 * Plain HTTP is only permitted for loopback addresses, to allow local development
+	 * against a locally hosted OAuth provider.
+	 * @param url - The OAuth URL to validate.
+	 * @param fieldName - The name of the field being validated, used in error messages.
+	 * @throws {CatalystConnectorError} when the URL is missing, malformed, or insecure.
+	 */
+	#validateOAuthUrl(url: string, fieldName: string): void {
+		if (!isURL(url)) {
+			throw new CatalystConnectorError(
+				'INVALID_OAUTH_URL',
+				`The ${fieldName} must be a valid, absolute URL.`
+			);
+		}
+		const parsedUrl = new URL(url);
+		const isLoopbackHost =
+			parsedUrl.hostname === 'localhost' ||
+			parsedUrl.hostname === '127.0.0.1' ||
+			parsedUrl.hostname === '::1';
+		if (parsedUrl.protocol !== 'https:' && !isLoopbackHost) {
+			throw new CatalystConnectorError(
+				'INSECURE_OAUTH_URL',
+				`The ${fieldName} must use HTTPS. Plain HTTP is only permitted for local development ` +
+					`against loopback addresses (localhost/127.0.0.1).`
+			);
+		}
+	}
+
 	/**
 	 * Retrieves a valid access token, refreshing or reading from cache when needed.
 	 * @returns A promise that resolves to string.
@@ -140,6 +171,7 @@ export class Connector {
 			isNonEmptyString(code, 'grant_token', true);
 			isNonEmptyString(this.redirectUrl, REDIRECT_URL, true);
 		}, CatalystConnectorError);
+		this.#validateOAuthUrl(this.authUrl, AUTH_URL);
 		const request: IRequestConfig = {
 			method: REQ_METHOD.post,
 			url: this.authUrl,
@@ -150,7 +182,8 @@ export class Connector {
 				[CLIENT_SECRET]: this.clientSecret,
 				[REDIRECT_URL]: this.redirectUrl
 			},
-			service: CatalystService.BAAS
+			service: CatalystService.EXTERNAL,
+			auth: false
 		};
 		const resp = await this.requester.send(request);
 		const tokenObj = resp.data;
@@ -200,6 +233,7 @@ export class Connector {
 			isNonEmptyString(this.refreshToken, 'refresh_token', true);
 			isNonEmptyString(this.refreshUrl, 'refresh_url', true);
 		}, CatalystConnectorError);
+		this.#validateOAuthUrl(this.refreshUrl, REFRESH_URL);
 		const request: IRequestConfig = {
 			method: REQ_METHOD.post,
 			url: this.refreshUrl,
@@ -209,7 +243,8 @@ export class Connector {
 				[CLIENT_SECRET]: this.clientSecret,
 				[REFRESH_TOKEN]: this.refreshToken
 			},
-			service: CatalystService.BAAS
+			service: CatalystService.EXTERNAL,
+			auth: false
 		};
 		const resp = await this.requester.send(request);
 		const tokenObject = resp.data;

--- a/packages/connector/tests/oauth-security.test.ts
+++ b/packages/connector/tests/oauth-security.test.ts
@@ -1,0 +1,121 @@
+import { CatalystService } from '@zcatalyst/utils';
+
+import { Connection } from '../src';
+import { CatalystConnectorError } from '../src/utils/error';
+
+// Mock @zcatalyst/cache so putAccessTokenInCache() doesn't hit the network.
+jest.mock('@zcatalyst/cache', () => {
+	return {
+		Cache: class {
+			segment() {
+				return {
+					put: jest.fn().mockResolvedValue({
+						cache_name: 'ZC_CONN_demo',
+						cache_value: '{}'
+					})
+				};
+			}
+		}
+	};
+});
+
+// Capture the config passed to the transport layer instead of hitting the network,
+// so we can assert on how the connector classifies its OAuth requests.
+const mockSend = jest.fn();
+jest.mock('@zcatalyst/transport', () => {
+	const actual = jest.requireActual('@zcatalyst/transport');
+	return {
+		...actual,
+		Handler: class {
+			async send(options: unknown) {
+				return mockSend(options);
+			}
+		}
+	};
+});
+
+const tokenResponse = {
+	access_token: 'third-party-token',
+	refresh_token: 'third-party-refresh-token',
+	expires_in: '3600'
+};
+
+const basePropJson = {
+	demo: {
+		client_id: 'third-party-client',
+		client_secret: 'third-party-secret',
+		auth_url: 'https://oauth.example.com/authorize',
+		refresh_url: 'https://oauth.example.com/refresh',
+		refresh_token: 'third-party-refresh-token',
+		expires_in: '3600',
+		refresh_in: '3000',
+		redirect_url: 'https://app.example/callback'
+	}
+};
+
+type CapturedRequest = { service?: CatalystService; auth?: boolean; url?: string };
+
+describe('connector OAuth requests do not leak Catalyst credentials', () => {
+	beforeEach(() => {
+		mockSend.mockReset();
+		mockSend.mockResolvedValue({ data: tokenResponse });
+	});
+
+	it('marks generateAccessToken requests as EXTERNAL with auth disabled', async () => {
+		const connection = new Connection(basePropJson);
+		const connector = connection.getConnector('demo');
+
+		await connector.generateAccessToken('auth-code');
+
+		expect(mockSend).toHaveBeenCalledTimes(1);
+		const requestConfig = mockSend.mock.calls[0][0] as CapturedRequest;
+		expect(requestConfig.service).toBe(CatalystService.EXTERNAL);
+		expect(requestConfig.auth).toBe(false);
+		expect(requestConfig.url).toBe(basePropJson.demo.auth_url);
+	});
+
+	it('marks refreshAccessToken requests as EXTERNAL with auth disabled', async () => {
+		const connection = new Connection(basePropJson);
+		const connector = connection.getConnector('demo');
+
+		await connector.refreshAccessToken();
+
+		expect(mockSend).toHaveBeenCalledTimes(1);
+		const requestConfig = mockSend.mock.calls[0][0] as CapturedRequest;
+		expect(requestConfig.service).toBe(CatalystService.EXTERNAL);
+		expect(requestConfig.auth).toBe(false);
+		expect(requestConfig.url).toBe(basePropJson.demo.refresh_url);
+	});
+
+	it('rejects a plain-HTTP, non-loopback auth_url', async () => {
+		const connection = new Connection({
+			demo: { ...basePropJson.demo, auth_url: 'http://oauth.example.com/authorize' }
+		});
+		const connector = connection.getConnector('demo');
+
+		await expect(connector.generateAccessToken('auth-code')).rejects.toThrow(
+			CatalystConnectorError
+		);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('rejects a malformed refresh_url', async () => {
+		const connection = new Connection({
+			demo: { ...basePropJson.demo, refresh_url: 'not-a-url' }
+		});
+		const connector = connection.getConnector('demo');
+
+		await expect(connector.refreshAccessToken()).rejects.toThrow(CatalystConnectorError);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('allows a plain-HTTP loopback refresh_url for local development', async () => {
+		const connection = new Connection({
+			demo: { ...basePropJson.demo, refresh_url: 'http://127.0.0.1:4000/refresh' }
+		});
+		const connector = connection.getConnector('demo');
+
+		await expect(connector.refreshAccessToken()).resolves.toBeUndefined();
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
# Description

Fixes a security bug in `@zcatalyst/connector` where Catalyst credentials (Authorization token, project key/secret, user header) were sent to third-party OAuth endpoints during token generation/refresh.

## Problem

`generateAccessToken()` and `refreshAccessToken()` marked their requests as `CatalystService.BAAS`, causing the transport layer to attach Catalyst auth headers to the configured `auth_url`/`refresh_url` — even though these are external, user-supplied OAuth endpoints. A malicious or compromised OAuth provider could capture and replay these credentials.

## Fix

- Changed both requests to use `service: CatalystService.EXTERNAL, auth: false`, so Catalyst credentials are no longer attached.
- Added `#validateOAuthUrl()` to require HTTPS for `auth_url`/`refresh_url`, allowing plain HTTP only for loopback hosts (localhost/127.0.0.1) for local development.

## Tests

- Added `tests/oauth-security.test.ts` verifying both requests use `EXTERNAL`/`auth: false`, and that insecure/malformed URLs are rejected.
- Verified with a PoC capture server that credentials are no longer leaked.
- Build and lint pass.

### Checklist
- [ ] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [ ] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
