### PR TITLE
fix(stratus): fixed the bucket url formation issue

### DIFF
--- a/packages/stratus/src/bucket.ts
+++ b/packages/stratus/src/bucket.ts
@@ -61,6 +61,13 @@ export class Bucket {
 					: (window.__catalyst?.environment as string)?.toLowerCase();
 			const domainSuffix =
 				typeof window === 'undefined' ? STRATUS_SUFFIX : window.__catalyst?.stratus_suffix;
+			if (!domainSuffix) {
+				throw new CatalystStratusError(
+					'invalid-argument',
+					'Unable to resolve Stratus domain suffix for bucket URL construction.',
+					bucket
+				);
+			}
 			const suffix =
 				environment === 'development' ? `-development${domainSuffix}` : domainSuffix;
 			const bucketUrl = `https://${bucket}${suffix}`;

--- a/packages/stratus/src/bucket.ts
+++ b/packages/stratus/src/bucket.ts
@@ -55,13 +55,15 @@ export class Bucket {
 		this.#jwtAuth = new JWTAuthHandler(this);
 		if (typeof bucket === 'string') {
 			assertValidBucketName(bucket);
-			const suffix =
+			const environment =
 				typeof window === 'undefined'
-					? `${(this._requester.app?.config?.environment as string).toLowerCase()}${STRATUS_SUFFIX}`
-					: (window.__catalyst?.environment as string)?.toLowerCase() +
-						'' +
-						window.__catalyst?.stratus_suffix;
-			const bucketUrl = `https://${bucket}-${suffix}`;
+					? (this._requester.app?.config?.environment as string)?.toLowerCase()
+					: (window.__catalyst?.environment as string)?.toLowerCase();
+			const domainSuffix =
+				typeof window === 'undefined' ? STRATUS_SUFFIX : window.__catalyst?.stratus_suffix;
+			const suffix =
+				environment === 'development' ? `-development${domainSuffix}` : domainSuffix;
+			const bucketUrl = `https://${bucket}${suffix}`;
 			assertValidBucketUrl(bucketUrl, bucket, suffix);
 			this._bucketDetails = {
 				bucket_name: bucket,

--- a/packages/stratus/src/utils/validator.ts
+++ b/packages/stratus/src/utils/validator.ts
@@ -42,7 +42,7 @@ export function assertValidBucketName(bucketName: unknown): asserts bucketName i
  * reintroduce an authority-injection bypass.
  * @param bucketUrl - The constructed bucket URL to verify.
  * @param bucketName - The bucket name used to construct the URL.
- * @param suffix - The expected hostname suffix (environment + Stratus domain suffix).
+ * @param suffix - The expected hostname suffix after the bucket name
  * @throws {CatalystStratusError} when the URL does not match the expected authority.
  */
 export function assertValidBucketUrl(bucketUrl: string, bucketName: string, suffix: string): void {
@@ -56,7 +56,7 @@ export function assertValidBucketUrl(bucketUrl: string, bucketName: string, suff
 			bucketName
 		);
 	}
-	const expectedHost = `${bucketName}-${suffix}`.toLowerCase();
+	const expectedHost = `${bucketName}${suffix}`.toLowerCase();
 	if (
 		parsed.protocol !== 'https:' ||
 		parsed.username !== '' ||

--- a/packages/stratus/tests/validator.test.ts
+++ b/packages/stratus/tests/validator.test.ts
@@ -52,7 +52,7 @@ describe('bucket url validation', () => {
 			assertValidBucketUrl(
 				'https://sample-development.zohostratus.com',
 				'sample',
-				'development.zohostratus.com'
+				'-development.zohostratus.com'
 			)
 		).not.toThrow();
 	});
@@ -62,13 +62,13 @@ describe('bucket url validation', () => {
 			assertValidBucketUrl(
 				'https://capture.example/#-development.zohostratus.com',
 				'capture.example/#',
-				'development.zohostratus.com'
+				'-development.zohostratus.com'
 			)
 		).toThrow();
 	});
 
 	it('rejects a URL with userinfo, port, query, or hash', () => {
-		const suffix = 'development.zohostratus.com';
+		const suffix = '-development.zohostratus.com';
 		expect(() =>
 			assertValidBucketUrl(
 				'https://user:pass@sample-development.zohostratus.com',
@@ -100,8 +100,14 @@ describe('bucket url validation', () => {
 			assertValidBucketUrl(
 				'http://sample-development.zohostratus.com',
 				'sample',
-				'development.zohostratus.com'
+				'-development.zohostratus.com'
 			)
 		).toThrow();
+	});
+
+	it('accepts a URL formed with just the bucket name for non-development environments', () => {
+		expect(() =>
+			assertValidBucketUrl('https://sample.zohostratus.com', 'sample', '.zohostratus.com')
+		).not.toThrow();
 	});
 });


### PR DESCRIPTION
### Issue
#27 

### Description
Updates Stratus bucket domain formation so the `-development` suffix is only appended when the resolved environment is `development`. Production environment now form the bucket URL using just the bucket name plus the Stratus domain suffix, instead of always appending an environment segment.

### Checklist
- [x] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [x] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
