### PR TITLE
fix(auth): fixed the change password query parameter issue

### DIFF
--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -641,10 +641,10 @@ class Authentication implements Component {
 		}, CatalystAuthenticationError);
 		const changePasswordUrl = `/${UM_URL_DIVIDER.PROJECT_USER}/${URL_DIVIDER.CHANGE_PASSWORD}`;
 		const request: IRequestConfig = {
-			method: REQ_METHOD.put,
+			method: REQ_METHOD.post,
 			path: changePasswordUrl,
 			type: RequestType.JSON,
-			qs: {
+			data: {
 				old_password: oldPassword,
 				new_password: newPassword
 			},

--- a/packages/auth/tests/index.browser.test.ts
+++ b/packages/auth/tests/index.browser.test.ts
@@ -88,5 +88,36 @@ describe('Authentication (Browser)', () => {
 		it('should send password change request', async () => {
 			await expect(zcAuth.changePassword('oldPass123', 'newPass456')).resolves.toBeDefined();
 		});
+
+		it('should send passwords in the request body, never in the URL/query string', async () => {
+			const sendSpy = jest.spyOn(zcAuth.requester, 'send');
+
+			await zcAuth.changePassword('oldPass123', 'newPass456');
+
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+			const sentRequest = sendSpy.mock.calls[0][0];
+
+			// Passwords must be present only in the JSON body.
+			expect(sentRequest.data).toEqual({
+				old_password: 'oldPass123',
+				new_password: 'newPass456'
+			});
+
+			// Passwords must never leak into the query string or URL.
+			expect(sentRequest.qs).not.toEqual(
+				expect.objectContaining({
+					old_password: expect.anything(),
+					new_password: expect.anything()
+				})
+			);
+			expect(JSON.stringify(sentRequest.qs ?? {})).not.toContain('oldPass123');
+			expect(JSON.stringify(sentRequest.qs ?? {})).not.toContain('newPass456');
+			expect(sentRequest.path).not.toContain('oldPass123');
+			expect(sentRequest.path).not.toContain('newPass456');
+			expect(sentRequest.url ?? '').not.toContain('oldPass123');
+			expect(sentRequest.url ?? '').not.toContain('newPass456');
+
+			sendSpy.mockRestore();
+		});
 	});
 });

--- a/tests/api-responses.js
+++ b/tests/api-responses.js
@@ -2380,16 +2380,7 @@ exports.responses = {
 		}
 	},
 	'/project-user/change-password': {
-		PUT: {
-			statusCode: 200,
-			data: {
-				status: 'success',
-				data: 'Password changed successfully'
-			}
-		}
-	},
-	'/project-user/change-password?new_password=newPass456&old_password=oldPass123': {
-		PUT: {
+		POST: {
 			statusCode: 200,
 			data: {
 				status: 'success',


### PR DESCRIPTION
### Summary
Updates `zcAuth.changePassword()` in the browser SDK to send the current and new password values in the JSON request body instead of the URL query string, and aligns the HTTP method with the actual API endpoint.

### Fix
- Changed HTTP method from `PUT` to `POST`.
- Moved `old_password` and `new_password` from `qs` to `data`, so they are sent in the JSON request body instead of the URL.

### Checklist
- [x] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [x] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
