### PR TITLE
fix(auth-admin): fixed the auth object properties exist in error issue

### DIFF
--- a/packages/auth-admin/src/credential.ts
+++ b/packages/auth-admin/src/credential.ts
@@ -33,8 +33,14 @@ const SENSITIVE_FIELDS = new Set(
 		PROJECT_HEADER.key,
 		PROJECT_HEADER.projectSecretKey,
 		'access_token',
+		'accessToken',
 		'refresh_token',
+		'refreshToken',
 		'client_secret',
+		'clientSecret',
+		'adminToken',
+		'userToken',
+		'cookie',
 		'ticket'
 	].map((field) => field.toLowerCase())
 );

--- a/packages/auth-admin/src/credential.ts
+++ b/packages/auth-admin/src/credential.ts
@@ -44,7 +44,7 @@ const SENSITIVE_FIELDS = new Set(
 		'ticket',
 		CSRF_TOKEN_NAME,
 		'zcrf_header',
-		'authroization'
+		'Authorization'
 	].map((field) => field.toLowerCase())
 );
 

--- a/packages/auth-admin/src/credential.ts
+++ b/packages/auth-admin/src/credential.ts
@@ -43,7 +43,8 @@ const SENSITIVE_FIELDS = new Set(
 		'cookie',
 		'ticket',
 		CSRF_TOKEN_NAME,
-		'zcrf_header'
+		'zcrf_header',
+		'authroization'
 	].map((field) => field.toLowerCase())
 );
 

--- a/packages/auth-admin/src/credential.ts
+++ b/packages/auth-admin/src/credential.ts
@@ -14,10 +14,46 @@ const {
 	CREDENTIAL_TYPE,
 	CREDENTIAL_USER,
 	CSRF_TOKEN_NAME,
-	ACCOUNTS_ORIGIN
+	ACCOUNTS_ORIGIN,
+	PROJECT_HEADER
 } = CONSTANTS;
 
 export const globalValue = {};
+
+const REDACTED = '[REDACTED]';
+
+// Header/property names that carry secrets and must never be echoed back in errors.
+const SENSITIVE_FIELDS = new Set(
+	[
+		CREDENTIAL_HEADER.admin_token,
+		CREDENTIAL_HEADER.user_token,
+		CREDENTIAL_HEADER.cookie,
+		CREDENTIAL_HEADER.signature,
+		CREDENTIAL_HEADER.zcsrf,
+		PROJECT_HEADER.key,
+		PROJECT_HEADER.projectSecretKey,
+		'access_token',
+		'refresh_token',
+		'client_secret',
+		'ticket'
+	].map((field) => field.toLowerCase())
+);
+
+/*
+ * Returns a shallow copy of the given object with any known credential/secret
+ * fields replaced so it can be safely attached to an error's `value` for
+ * debugging without leaking admin tokens, project keys, cookies, etc.
+ */
+function redactSensitiveFields(source: unknown): unknown {
+	if (typeof source !== 'object' || source === null) {
+		return source;
+	}
+	const redacted: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(source as Record<string, unknown>)) {
+		redacted[key] = SENSITIVE_FIELDS.has(key.toLowerCase()) ? REDACTED : val;
+	}
+	return redacted;
+}
 
 const CREDENTIAL_PATH = process.env.HOME
 	? resolve(resolve(process.env.HOME, '.config'), CREDENTIAL_SUFFIX)
@@ -29,7 +65,7 @@ function getAttr(from: { [x: string]: string | undefined }, key: string, alt?: s
 		throw new CatalystAuthError(
 			'INVALID_CREDENTIAL',
 			`Unable to get ${alt} from credential Object provided`,
-			from
+			redactSensitiveFields(from)
 		);
 	}
 	return tmp;
@@ -418,7 +454,7 @@ export class CatalystCredential extends Credential {
 				throw new CatalystAuthError(
 					'AUTH_ERROR',
 					'User not authenticated. Please login to proceed with user scope',
-					credObj
+					redactSensitiveFields(credObj)
 				);
 			}
 
@@ -427,7 +463,7 @@ export class CatalystCredential extends Credential {
 				throw new CatalystAuthError(
 					'INVALID_CREDENTIAL',
 					'missing user credentials',
-					credObj
+					redactSensitiveFields(credObj)
 				);
 			}
 		}
@@ -443,7 +479,7 @@ export class CatalystCredential extends Credential {
 				throw new CatalystAuthError(
 					'INVALID_CREDENTIAL',
 					'admin credential type is unknown',
-					credObj
+					redactSensitiveFields(credObj)
 				);
 		}
 		switch (this.userCredType) {
@@ -585,7 +621,7 @@ export class ApplicationDefaultCredential extends Credential {
 			throw new CatalystAuthError(
 				'INVALID_CREDENTIAL',
 				'Unable to get token object from path or env',
-				token
+				redactSensitiveFields(token)
 			);
 		}
 
@@ -599,7 +635,7 @@ export class ApplicationDefaultCredential extends Credential {
 			throw new CatalystAuthError(
 				'INVALID_CREDENTIAL',
 				'The given token object does not contain proper credentials',
-				token
+				redactSensitiveFields(token)
 			);
 		}
 	}
@@ -637,7 +673,7 @@ export class ApplicationCustomCredential extends Credential {
 			throw new CatalystAuthError(
 				'INVALID_CREDENTIAL',
 				'Unable to get token object from path or env',
-				credObj
+				redactSensitiveFields(credObj)
 			);
 		}
 
@@ -651,7 +687,7 @@ export class ApplicationCustomCredential extends Credential {
 			throw new CatalystAuthError(
 				'INVALID_CREDENTIAL',
 				'The given token object does not contain proper credentials',
-				credObj
+				redactSensitiveFields(credObj)
 			);
 		}
 	}

--- a/packages/auth-admin/src/credential.ts
+++ b/packages/auth-admin/src/credential.ts
@@ -41,7 +41,9 @@ const SENSITIVE_FIELDS = new Set(
 		'adminToken',
 		'userToken',
 		'cookie',
-		'ticket'
+		'ticket',
+		CSRF_TOKEN_NAME,
+		'zcrf_header'
 	].map((field) => field.toLowerCase())
 );
 


### PR DESCRIPTION
###Summary

`CatalystAuthError` was storing the full credential/header object (including the project admin token and project key) as its `value`. Since `CatalystError.toJSON()`/`toString()` return `value` as-is, logging or serializing this error leaked live secrets — even to unauthenticated callers.

### Fix

Added `redactSensitiveFields()` in `packages/auth-admin/src/credential.ts` and used it everywhere a credential/token object is attached to a `CatalystAuthError`. It replaces known secret fields (admin/user tokens, cookie, signature, CSRF, project key/secret, `access_token`, `refresh_token`, `client_secret`, `ticket`) with `'[REDACTED]'`, keeping other fields intact for debugging.

## #Files Changed

- `packages/auth-admin/src/credential.ts`

### Checklist
- [ ] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [ ] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
