### PR TITLE
feat(datastream): add a datastream support

### DIFF
--- a/packages/datastreams/CHANGELOG.md
+++ b/packages/datastreams/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @zcatalyst/datastreams

--- a/packages/datastreams/README.md
+++ b/packages/datastreams/README.md
@@ -1,0 +1,520 @@
+# @zcatalyst/datastreams
+
+JavaScript SDK for Catalyst Data Streams - Real-Time Data Streaming
+
+## Overview
+
+The `@zcatalyst/datastreams` package provides JavaScript/TypeScript methods to implement [Catalyst Data Streams](https://docs.catalyst.zoho.com/en/cloud-scale/help/data-streams/introduction/), a real-time publish-subscribe messaging service for bidirectional communication between clients and servers.
+
+**Catalyst Data Streams** enables WebSocket-based real-time communication, allowing you to build collaborative applications, live dashboards, and instant notification systems.
+
+### Key Features
+
+- **Real-Time Communication**: WebSocket-based instant messaging
+- **Pub/Sub Architecture**: Publisher-subscriber pattern
+- **Bidirectional**: Two-way communication between clients and server
+- **Channel Management**: Organize streams into channels
+- **Live Connection Tracking**: Monitor active connections
+- **Token-Based Auth**: Secure channel access with tokens
+- **Multi-Client**: Support multiple simultaneous connections
+- **Scalable**: Handle high-volume real-time data
+
+### Use Cases
+
+- Build real-time chat applications
+- Live dashboards and analytics
+- Collaborative editing tools
+- Real-time notifications and alerts
+- Live game updates and leaderboards
+- IoT device communication
+- Stock tickers and price updates
+- Social media feeds
+
+### Prerequisites
+
+- A [Catalyst project](https://docs.catalyst.zoho.com/en/getting-started/catalyst-projects) set up
+- Data Stream channels created
+- Understanding of [WebSocket communication](https://docs.catalyst.zoho.com/en/cloud-scale/help/data-streams/websocket/)
+- Token pair generation for authentication
+
+## Installation
+
+To install this package, simply type add or install @zcatalyst/datastreams
+using your favorite package manager:
+
+- `npm install @zcatalyst/datastreams`
+- `yarn add @zcatalyst/datastreams`
+- `pnpm add @zcatalyst/datastreams`
+
+## Getting Started
+
+### Import
+
+The Catalyst SDK provides real-time data streaming capabilities.
+To use data streams, import the `DataStreams`:
+
+```js
+// ES5 example
+const { DataStreams } = require("@zcatalyst/datastreams");
+```
+
+```ts
+// ES6+ example
+import { DataStreams } from "@zcatalyst/datastreams";
+```
+
+### Usage
+
+#### Node.js Environment
+
+For server-side data streaming operations:
+
+```js
+const dataStreams = new DataStreams(app);
+
+// Get token pair for channel authentication
+const tokenPair = await dataStreams.getTokenPair('channel-id', {
+  userId: 'user123'
+});
+
+// Get all channels
+const channels = await dataStreams.getAllChannels();
+
+// Get channel details
+const channelDetails = await dataStreams.getChannelDetails('channel-id');
+
+// Get live connection count
+const liveCount = await dataStreams.getLiveCount('channel-id');
+
+// Publish data to channel
+const result = await dataStreams.publishData('channel-id', 'Hello subscribers!');
+```
+
+#### Browser Environment
+
+For client-side real-time data consumption:
+
+```js
+// Get token pair first (from server API)
+const tokenPair = await fetch('/api/get-token-pair').then(res => res.json());
+
+// Create WebSocket connection
+const ws = new DataStreamsWebSocket({
+  url: 'your-catalyst-domain.com',
+  key: tokenPair.key,
+  zuid: tokenPair.zuid,
+  enableLogging: true
+});
+
+// Handle connection events
+ws.on('open', (event) => {
+  console.log('Connected to data stream');
+  // Subscribe to live events
+  ws.subscribe('0'); // 0 = live events
+});
+
+ws.on('message', (event) => {
+  console.log('Received data:', event.data);
+  console.log('Streaming ID:', event.streamingId);
+
+  // Send acknowledgement to receive next message
+  ws.sendAck();
+});
+
+ws.on('error', (error) => {
+  console.error('WebSocket error:', error);
+});
+
+ws.on('close', (event) => {
+  console.log('Connection closed');
+});
+```
+
+### WebSocket Connection
+
+The `DataStreamsWebSocket` class provides low-level WebSocket access:
+
+```js
+import { DataStreamsWebSocket } from '@zcatalyst/datastreams';
+
+// Create WebSocket connection
+const ws = new DataStreamsWebSocket('ws://localhost:8080/stream');
+
+// Handle connection events
+ws.on('open', () => {
+  console.log('Connected to data stream');
+});
+
+ws.on('message', (data) => {
+  console.log('Received message:', data);
+});
+
+ws.on('error', (error) => {
+  console.error('WebSocket error:', error);
+});
+
+ws.on('close', () => {
+  console.log('Disconnected from data stream');
+});
+
+// Send message
+ws.send(JSON.stringify({ type: 'ping' }));
+```
+
+### Environment Support
+
+This package automatically detects the environment and uses appropriate WebSocket implementations:
+
+- **Node.js**: Uses `ws` WebSocket library
+- **Browser**: Uses native WebSocket API
+
+## Async/await
+
+We recommend using [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+operator to wait for the promise returned by data stream operations:
+
+```js
+// async/await.
+try {
+  const stream = await dataStreams.create(config);
+  // process stream creation.
+} catch (error) {
+  // error handling.
+} finally {
+  // finally.
+}
+```
+
+## Error Handling
+
+When the service returns an exception, the error will include the exception information,
+as well as response metadata (e.g. request id).
+
+```js
+try {
+  const stream = await dataStreams.create(config);
+  // process stream.
+} catch (error) {
+  const message = error.message;
+  const status = error.statusCode;
+  console.log({ message, status });
+}
+```
+
+## API Reference
+
+### DataStreams Admin Methods
+
+<details>
+<summary>
+Get Token Pair
+</summary>
+
+```js
+const tokenPair = await dataStreams.getTokenPair('channel-id', {
+  userId: 'user123'        // or connectionName: 'connection-name'
+});
+
+// Response format
+console.log(tokenPair.key);     // WebSocket authentication key
+console.log(tokenPair.zuid);    // User ID for WebSocket connection
+```
+
+</details>
+
+<details>
+<summary>
+Get All Channels
+</summary>
+
+```js
+const channels = await dataStreams.getAllChannels();
+
+// Response contains array of all available channels
+channels.forEach(channel => {
+  console.log('Channel ID:', channel.id);
+  console.log('Channel Name:', channel.name);
+  console.log('Channel Description:', channel.description);
+});
+```
+
+</details>
+
+<details>
+<summary>
+Get Channel Details
+</summary>
+
+```js
+const channelDetails = await dataStreams.getChannelDetails('channel-id');
+
+console.log('Channel info:', {
+  id: channelDetails.id,
+  name: channelDetails.name,
+  description: channelDetails.description,
+  created_at: channelDetails.created_at,
+  status: channelDetails.status
+});
+```
+
+</details>
+
+<details>
+<summary>
+Get Live Connection Count
+</summary>
+
+```js
+const liveCount = await dataStreams.getLiveCount('channel-id');
+
+console.log('Active connections:', liveCount.count);
+console.log('Last updated:', liveCount.timestamp);
+```
+
+</details>
+
+<details>
+<summary>
+Publish Data to Channel
+</summary>
+
+```js
+const result = await dataStreams.publishData('channel-id', 'Hello subscribers!');
+
+// Returns true if data was published successfully
+if (result) {
+  console.log('Data published successfully');
+} else {
+  console.log('Failed to publish data');
+}
+```
+
+</details>
+
+### DataStreams WebSocket Methods
+
+<details>
+<summary>
+Create WebSocket Connection
+</summary>
+
+```js
+const ws = new DataStreamsWebSocket({
+  url: 'your-catalyst-domain.com',
+  key: 'websocket-auth-key',
+  zuid: 'user-id',
+  enableLogging: true    // Optional: enable debug logging
+});
+```
+
+</details>
+
+<details>
+<summary>
+Subscribe to Channel Events
+</summary>
+
+```js
+// Subscribe to live events (0 = live, -1 = earliest, -2 = resume, streaming-id = specific)
+ws.subscribe('0');
+
+// Subscribe after connection is established
+ws.on('open', () => {
+  ws.subscribe('0');
+});
+```
+
+</details>
+
+<details>
+<summary>
+Handle WebSocket Events
+</summary>
+
+```js
+// Connection established
+ws.on('open', (event) => {
+  console.log('Connected:', event.message);
+});
+
+// Receive data messages
+ws.on('message', (event) => {
+  console.log('Data:', event.data);
+  console.log('Streaming ID:', event.streamingId);
+
+  // Send acknowledgement to receive next message
+  ws.sendAck();
+});
+
+// Handle errors
+ws.on('error', (error) => {
+  console.error('Error:', error.code, error.message);
+
+  // Handle specific error codes
+  switch (error.code) {
+    case 3000: // Authentication failed
+      console.log('Please generate new credentials');
+      break;
+    case 1000: // Session expired
+      console.log('Reconnecting with new credentials');
+      break;
+    case 1013: // Connection blocked
+      console.log('Contact support');
+      break;
+  }
+});
+
+// Connection closed
+ws.on('close', (event) => {
+  console.log('Connection closed');
+});
+
+// Pong response (for ping)
+ws.on('pong', (event) => {
+  console.log('Pong received:', event.message);
+});
+```
+
+</details>
+
+<details>
+<summary>
+Unsubscribe from Channel
+</summary>
+
+```js
+ws.unsubscribe();
+```
+
+</details>
+
+<details>
+<summary>
+Send Acknowledgement
+</summary>
+
+```js
+// Send acknowledgement to receive next message
+ws.sendAck();
+
+// Usually called after processing a message
+ws.on('message', (event) => {
+  // Process the message
+  processData(event.data);
+
+  // Send acknowledgement
+  ws.sendAck();
+});
+```
+
+</details>
+
+<details>
+<summary>
+Check Connection Status
+</summary>
+
+```js
+// Check if connected
+if (ws.isConnected()) {
+  console.log('WebSocket is connected');
+}
+
+// Get connection state
+const state = ws.getConnectionState();
+console.log('Connection state:', state); // 'connected', 'connecting', 'closing', 'closed'
+
+// Get session info
+const session = ws.getSessionInfo();
+console.log('Session ID:', session.sid);
+console.log('User ID:', session.uid);
+```
+
+</details>
+
+<details>
+<summary>
+Close Connection
+</summary>
+
+```js
+ws.close();
+```
+
+</details>
+
+### Data Format
+
+#### Token Pair Response
+
+```js
+{
+  key: "websocket-authentication-key",
+  zuid: "user-identifier"
+}
+```
+
+#### Channel Information
+
+```js
+{
+  id: "channel-id",
+  name: "channel-name",
+  description: "channel-description",
+  created_at: "2023-01-01T00:00:00.000Z",
+  status: "active"
+}
+```
+
+#### WebSocket Message Event
+
+```js
+{
+  data: "message-content",
+  streamingId: "unique-streaming-id",
+  url: "optional-api-url",     // For API operation messages
+  method: "optional-http-method" // For API operation messages
+}
+```
+
+#### WebSocket Error Event
+
+```js
+{
+  code: 3000,                  // Error code
+  message: "Error description"
+}
+```
+
+### Common Error Codes
+
+- **3000** - Authentication failed, generate new credentials
+- **1000** - Session expired, reconnect with new credentials
+- **1013** - Connection blocked, contact support
+- **1011** - Server down, retry after a minute
+- **1014** - Missing key parameter
+
+### Subscribe Types
+
+- **"0"** - Live events (default)
+- **"-1"** - Earliest available events
+- **"-2"** - Resume from previous session
+- **streaming-id** - Specific streaming ID
+
+## Resources
+
+- [Catalyst Data Streams Documentation](https://docs.catalyst.zoho.com/en/cloud-scale/help/data-streams/introduction/)
+- [WebSocket Communication](https://docs.catalyst.zoho.com/en/cloud-scale/help/data-streams/websocket/)
+- [Channel Management](https://docs.catalyst.zoho.com/en/cloud-scale/help/data-streams/channel-management/)
+- [Data Streams SDK Reference](https://docs.catalyst.zoho.com/en/sdk/server-side-sdks/node-js-sdk/data-streams/)
+- [SDK Documentation](https://docs.catalyst.zoho.com/en/sdk/)
+
+## Contributing
+
+Contributions to this library are always welcome and highly encouraged.
+
+See [CONTRIBUTING](../../CONTRIBUTING.md) for more information on how to get started.
+
+## License
+
+This SDK is distributed under the Apache License 2.0. See [LICENSE](../../LICENCE) file for more information.

--- a/packages/datastreams/README.md
+++ b/packages/datastreams/README.md
@@ -100,7 +100,7 @@ const tokenPair = await fetch('/api/get-token-pair').then(res => res.json());
 
 // Create WebSocket connection
 const ws = new DataStreamsWebSocket({
-  url: 'your-catalyst-domain.com',
+  url: tokenPair.url,
   key: tokenPair.key,
   zuid: tokenPair.zuid,
   enableLogging: true
@@ -300,7 +300,7 @@ Create WebSocket Connection
 
 ```js
 const ws = new DataStreamsWebSocket({
-  url: 'your-catalyst-domain.com',
+  url: 'us4-dms.zoho.com',
   key: 'websocket-auth-key',
   zuid: 'user-id',
   enableLogging: true    // Optional: enable debug logging

--- a/packages/datastreams/jest.config.js
+++ b/packages/datastreams/jest.config.js
@@ -1,0 +1,8 @@
+const base = require("../../jest.config.base.js");
+
+module.exports =  {
+  ...base,
+    moduleNameMapper: {
+    "^@zcatalyst/transport$": "../../transport/src/__mocks__",
+  }
+};

--- a/packages/datastreams/jest.config.js
+++ b/packages/datastreams/jest.config.js
@@ -3,6 +3,6 @@ const base = require("../../jest.config.base.js");
 module.exports =  {
   ...base,
     moduleNameMapper: {
-    "^@zcatalyst/transport$": "../../transport/src/__mocks__",
+    "^@zcatalyst/transport$": "<rootDir>/../transport/src/__mocks__",
   }
 };

--- a/packages/datastreams/package.json
+++ b/packages/datastreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zcatalyst/datastreams",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "Catalyst DataStreams service client for managing real-time data channels",
   "main": "dist-cjs/index.js",
   "module": "dist-es/index.js",

--- a/packages/datastreams/package.json
+++ b/packages/datastreams/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "@zcatalyst/datastreams",
+  "version": "0.0.2",
+  "description": "Catalyst DataStreams service client for managing real-time data channels",
+  "main": "dist-cjs/index.js",
+  "module": "dist-es/index.js",
+  "types": "dist-types/index.d.ts",
+  "exports": {
+    ".": {
+      "node": {
+        "types": "./dist-types/index.d.ts",
+        "import": "./dist-es/index.js",
+        "require": "./dist-cjs/index.js"
+      },
+      "browser": {
+        "types": "./dist-types/index.browser.d.ts",
+        "import": "./dist-es/index.browser.js",
+        "require": "./dist-cjs/index.browser.js"
+      },
+      "default": {
+        "types": "./dist-types/index.d.ts",
+        "import": "./dist-es/index.js",
+        "require": "./dist-cjs/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist-cjs/",
+    "dist-es/",
+    "dist-types/",
+    "src/",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENCE"
+  ],
+  "keywords": [
+    "catalyst",
+    "datastreams",
+    "real-time",
+    "websocket",
+    "channels",
+    "zoho",
+    "sdk"
+  ],
+  "browser": {
+    "./dist-cjs/index.js": "./dist-cjs/index.browser.js",
+    "./dist-es/index.js": "./dist-es/index.browser.js",
+    "./dist-types/index.d.ts": "./dist-types/index.browser.d.ts",
+    "stream": false,
+    "crypto": false,
+    "fs": false,
+    "path": false,
+    "process": false
+  },
+  "author": "Zoho Corporation",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/catalystbyzoho/zcatalyst-sdk-js.git",
+    "directory": "packages/datastreams"
+  },
+  "bugs": {
+    "url": "https://github.com/catalystbyzoho/zcatalyst-sdk-js/issues"
+  },
+  "homepage": "https://github.com/catalystbyzoho/zcatalyst-sdk-js/tree/main/packages/datastreams#readme",
+  "scripts": {
+    "build": "concurrently 'pnpm:build:cjs' 'pnpm:build:es' 'pnpm:build:types && pnpm build:types:downlevel'",
+    "build:cjs": "pnpm tsc -p tsconfig.cjs.json",
+    "build:es": "pnpm tsc -p tsconfig.es.json",
+    "build:types": "pnpm tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.8",
+    "clean": "rm -rf dist-*",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@zcatalyst/utils": "workspace:*",
+    "@zcatalyst/transport": "workspace:*",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.30",
+    "@types/ws": "^8.18.1",
+    "concurrently": "^8.2.2",
+    "downlevel-dts": "^0.11.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.5",
+    "typescript": "^5.4.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/datastreams/src/datastreams.ts
+++ b/packages/datastreams/src/datastreams.ts
@@ -1,0 +1,282 @@
+/**
+ * Type definitions for Catalyst Datastreams module.
+ *
+ * This module contains type definitions and interfaces for the Catalyst Datastreams service,
+ * including token responses, channel details, and API responses.
+ */
+
+import { Handler, IRequestConfig, RequestType, ResponseType } from '@zcatalyst/transport';
+import {
+	CatalystService,
+	Component,
+	CONSTANTS,
+	isNonEmptyString,
+	isValidInputString,
+	wrapValidatorsWithPromise
+} from '@zcatalyst/utils';
+
+import pkg from '../package.json';
+const { version } = pkg;
+import { CatalystDataStreamError } from './utils/errors';
+import {
+	ApiResponse,
+	ChannelLiveCountResponse,
+	GetAllChannelsResponse,
+	GetChannelResponse,
+	TokenResponse
+} from './utils/interfaces';
+
+const { COMPONENT, REQ_METHOD, CREDENTIAL_USER, X_ZOHO_CATALYST_RESOURCE_ID } = CONSTANTS;
+
+/**
+ * DataStreams component class
+ *
+ * Provides methods to interact with Catalyst DataStreams service,
+ * including getting channel information, publishing data, and retrieving live counts.
+ */
+export class DataStreams implements Component {
+	protected requester: Handler;
+
+	/**
+	 * Initialize the DataStreams component
+	 *
+	 * @param app - The Catalyst application instance
+	 */
+	constructor(app?: unknown) {
+		this.requester = new Handler(app, this);
+	}
+
+	/**
+	 * Get the component name for this service
+	 *
+	 * @returns The component name 'Datastreams'
+	 */
+	getComponentName(): string {
+		return COMPONENT.data_streams;
+	}
+
+	getComponentVersion(): string {
+		return version;
+	}
+
+	/**
+	 * Get a token pair for a specific datastream channel
+	 *
+	 * This method retrieves a token pair that can be used to authenticate
+	 * and authorize access to the specified datastream channel.
+	 *
+	 * @param channelId - The unique identifier or name of the datastream channel
+	 * @param user - The user identifier, can be a user ID (number) or connection name (string)
+	 * @returns Response containing the token pair information
+	 * @throws CatalystDataStreamError if channelId is invalid or the request fails
+	 *
+	 * @example
+	 * ```typescript
+	 * const datastream = app.datastream();
+	 * const tokenPair = await datastream.getTokenPair("12345", "user123"); // Using ID and user ID
+	 * // or
+	 * const tokenPair = await datastream.getTokenPair("my_channel", "connection_name"); // Using name and connection name
+	 * console.log('token pair::', tokenPair);
+	 * ```
+	 */
+	async getTokenPair(
+		channelId: string | number,
+		{ userId, connectionName }: { userId?: string; connectionName?: string }
+	): Promise<ApiResponse<TokenResponse>> {
+		await wrapValidatorsWithPromise(() => {
+			isValidInputString(channelId, 'channelId', true);
+		}, CatalystDataStreamError);
+
+		if (
+			!isValidInputString(userId, 'userId', false) &&
+			!isValidInputString(connectionName, 'connectionName', false)
+		) {
+			throw new CatalystDataStreamError(
+				'INVALID_PARAM',
+				'Either userId or connectionName must be provided and valid.'
+			);
+		}
+
+		let payload: Record<string, unknown> = {};
+
+		// Try to convert string user to number if possible
+		if (userId) {
+			payload = { app_user_id: userId };
+		} else if (connectionName) {
+			payload = { connection_name: connectionName };
+		}
+
+		const request: IRequestConfig = {
+			method: REQ_METHOD.post,
+			path: `/datastreams/channel/${channelId}/tokenpair`,
+			data: payload,
+			headers: typeof window === 'undefined' ? this._addHeader({}) : {},
+			type: RequestType.JSON,
+			expecting: ResponseType.JSON,
+			user: CREDENTIAL_USER.user,
+			service: CatalystService.BAAS
+		};
+		const resp = await this.requester.send(request);
+		return resp.data.data;
+	}
+
+	_addHeader(headers: Record<string, string>): Record<string, string> {
+		const resourceId = process.env.X_ZOHO_CATALYST_RESOURCE_ID;
+		if (isNonEmptyString(resourceId)) {
+			headers[X_ZOHO_CATALYST_RESOURCE_ID] = resourceId as string;
+		}
+		return headers;
+	}
+}
+
+/**
+ * DataStreams component class
+ *
+ * Provides methods to interact with Catalyst DataStreams service,
+ * including getting channel information, publishing data, and retrieving live counts.
+ */
+export class DataStreamsAdmin extends DataStreams {
+	constructor(app?: unknown) {
+		super(app);
+	}
+
+	/**
+	 * Retrieve all datastream channels
+	 *
+	 * This method fetches all available datastream channels from the Catalyst service.
+	 *
+	 * @returns Response containing all datastream channels information
+	 * @throws CatalystDataStreamError if the request fails or returns an error
+	 *
+	 * @example
+	 * ```typescript
+	 * const datastream = app.datastream();
+	 * const res = await datastream.getAllChannels();
+	 * console.log('channels::', res);
+	 * ```
+	 */
+	async getAllChannels(): Promise<ApiResponse<GetAllChannelsResponse>> {
+		const request: IRequestConfig = {
+			method: REQ_METHOD.get,
+			path: '/datastreams/channel',
+			type: RequestType.JSON,
+			expecting: ResponseType.JSON,
+			user: CREDENTIAL_USER.admin,
+			service: CatalystService.BAAS
+		};
+		const resp = await this.requester.send(request);
+		return resp.data.data;
+	}
+
+	/**
+	 * Retrieve details of a specific datastream channel
+	 *
+	 * This method fetches detailed information about a specific datastream channel
+	 * identified by the provided channel ID or name.
+	 *
+	 * @param channelId - The unique identifier or name of the datastream channel
+	 * @returns Response containing the channel details
+	 * @throws CatalystDataStreamError if channelId is invalid or the request fails
+	 *
+	 * @example
+	 * ```typescript
+	 * const datastream = app.datastream();
+	 * const channelDetails = await datastream.getChannelDetails("12345"); // Using ID
+	 * // or
+	 * const channelDetails = await datastream.getChannelDetails("my_channel"); // Using name
+	 * console.log('channel details::', channelDetails);
+	 * ```
+	 */
+	async getChannelDetails(channelId: string): Promise<ApiResponse<GetChannelResponse>> {
+		await wrapValidatorsWithPromise(() => {
+			isValidInputString(channelId, 'channelId', true);
+		}, CatalystDataStreamError);
+		const request: IRequestConfig = {
+			method: REQ_METHOD.get,
+			path: `/datastreams/channel/${channelId}`,
+			type: RequestType.JSON,
+			expecting: ResponseType.JSON,
+			user: CREDENTIAL_USER.admin,
+			service: CatalystService.BAAS
+		};
+		const resp = await this.requester.send(request);
+		return resp.data.data;
+	}
+
+	/**
+	 * Get the live connection count for a specific datastream channel
+	 *
+	 * This method retrieves the number of active connections currently
+	 * subscribed to the specified datastream channel.
+	 *
+	 * @param channelId - The unique identifier or name of the datastream channel
+	 * @returns Response containing the live connection count information
+	 * @throws CatalystDataStreamError if channelId is invalid or the request fails
+	 *
+	 * @example
+	 * ```typescript
+	 * const datastream = app.datastream();
+	 * const liveCount = await datastream.getLiveCount("12345"); // Using ID
+	 * // or
+	 * const liveCount = await datastream.getLiveCount("my_channel"); // Using name
+	 * console.log('live count::', liveCount);
+	 * ```
+	 */
+	async getLiveCount(channelId: string): Promise<ApiResponse<ChannelLiveCountResponse>> {
+		await wrapValidatorsWithPromise(() => {
+			isValidInputString(channelId, 'channelId', true);
+		}, CatalystDataStreamError);
+
+		const request: IRequestConfig = {
+			method: REQ_METHOD.get,
+			path: `/datastreams/channel/${channelId}/liveclient`,
+			type: RequestType.JSON,
+			expecting: ResponseType.JSON,
+			user: CREDENTIAL_USER.admin,
+			service: CatalystService.BAAS
+		};
+		const resp = await this.requester.send(request);
+		return resp.data;
+	}
+
+	/**
+	 * Publish data to a specific datastream channel
+	 *
+	 * This method sends data to the specified datastream channel, which will be
+	 * broadcasted to all active subscribers of that channel.
+	 *
+	 * @param channelId - The unique identifier or name of the datastream channel
+	 * @param data - The data to be published to the channel
+	 * @returns Response containing the publish operation result
+	 * @throws CatalystDataStreamError if channelId or data is invalid, or the request fails
+	 *
+	 * @example
+	 * ```typescript
+	 * const datastream = app.datastream();
+	 * const result = await datastream.publishData("12345", "Hello, subscribers!"); // Using ID
+	 * // or
+	 * const result = await datastream.publishData("my_channel", "Hello, subscribers!"); // Using name
+	 * console.log('publish result::', result);
+	 * ```
+	 */
+	async publishData(channelId: string, data: string): Promise<boolean> {
+		await wrapValidatorsWithPromise(() => {
+			isValidInputString(channelId, 'channelId', true);
+			isNonEmptyString(data, 'data', true);
+		}, CatalystDataStreamError);
+
+		const payload: string = data;
+
+		const request: IRequestConfig = {
+			method: REQ_METHOD.post,
+			path: `/datastreams/channel/${channelId}/stream`,
+			data: { data: payload },
+			type: RequestType.JSON,
+			expecting: ResponseType.JSON,
+			user: CREDENTIAL_USER.admin,
+			service: CatalystService.BAAS
+		};
+		const resp = await this.requester.send(request);
+		return resp.data.data as unknown as boolean;
+	}
+}

--- a/packages/datastreams/src/index.browser.ts
+++ b/packages/datastreams/src/index.browser.ts
@@ -1,0 +1,6 @@
+/**
+ * DataStreams package - Catalyst DataStreams service operations
+ */
+
+export { DataStreams } from './datastreams';
+export { DataStreamsWebSocket } from './web-socket';

--- a/packages/datastreams/src/index.ts
+++ b/packages/datastreams/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * DataStreams package - Catalyst DataStreams service operations
+ */
+
+export { DataStreamsAdmin as DataStreams } from './datastreams';
+export { DataStreamsWebSocket } from './web-socket';

--- a/packages/datastreams/src/utils/enum.ts
+++ b/packages/datastreams/src/utils/enum.ts
@@ -1,0 +1,10 @@
+export enum MessageType {
+	SWITCH_URL = '-1',
+	MISSING_KEY = '-2',
+	AUTH_FAILED = '-5',
+	SESSION_EXPIRED = '-11',
+	AUTH_SUCCESS = '0',
+	BLOCKED = '660',
+	DATA_EVENT = '650',
+	SERVER_DOWN = '670'
+}

--- a/packages/datastreams/src/utils/errors.ts
+++ b/packages/datastreams/src/utils/errors.ts
@@ -1,0 +1,7 @@
+import { PrefixedCatalystError } from '@zcatalyst/utils';
+
+export class CatalystDataStreamError extends PrefixedCatalystError {
+	constructor(code: string, message: string, value?: unknown) {
+		super('app', code, message, value);
+	}
+}

--- a/packages/datastreams/src/utils/event-emitter.ts
+++ b/packages/datastreams/src/utils/event-emitter.ts
@@ -1,0 +1,107 @@
+/**
+ * Browser-compatible EventEmitter
+ *
+ * This provides a minimal EventEmitter implementation that works in both
+ * Node.js and browser environments without requiring Node.js built-in modules.
+ */
+
+type EventListener = (...args: Array<any>) => void;
+type EventMap = Map<string, Set<EventListener>>;
+
+/**
+ * Minimal EventEmitter implementation for cross-platform compatibility
+ */
+export class EventEmitter {
+	private events: EventMap = new Map();
+
+	/**
+	 * Register an event listener
+	 */
+	on(event: string, listener: EventListener): this {
+		if (!this.events.has(event)) {
+			this.events.set(event, new Set());
+		}
+		this.events.get(event)!.add(listener);
+		return this;
+	}
+
+	/**
+	 * Register a one-time event listener
+	 */
+	once(event: string, listener: EventListener): this {
+		const onceWrapper = (...args: Array<any>) => {
+			this.off(event, onceWrapper);
+			listener(...args);
+		};
+		return this.on(event, onceWrapper);
+	}
+
+	/**
+	 * Remove an event listener
+	 */
+	off(event: string, listener: EventListener): this {
+		const listeners = this.events.get(event);
+		if (listeners) {
+			listeners.delete(listener);
+			if (listeners.size === 0) {
+				this.events.delete(event);
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * Remove all listeners for an event, or all events if no event specified
+	 */
+	removeAllListeners(event?: string): this {
+		if (event) {
+			this.events.delete(event);
+		} else {
+			this.events.clear();
+		}
+		return this;
+	}
+
+	/**
+	 * Emit an event with arguments
+	 */
+	emit(event: string, ...args: Array<any>): boolean {
+		const listeners = this.events.get(event);
+		if (!listeners || listeners.size === 0) {
+			return false;
+		}
+
+		// Create array from set to avoid issues if listeners modify the set during iteration
+		const listenersArray = Array.from(listeners);
+		for (const listener of listenersArray) {
+			try {
+				listener(...args);
+			} catch (error) {
+				// Emit error event if available, otherwise log to console
+				if (event !== 'error') {
+					this.emit('error', error);
+				} else {
+					// eslint-disable-next-line no-console
+					console.error('EventEmitter error:', error);
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Get the number of listeners for an event
+	 */
+	listenerCount(event: string): number {
+		const listeners = this.events.get(event);
+		return listeners ? listeners.size : 0;
+	}
+
+	/**
+	 * Get all listeners for an event
+	 */
+	listeners(event: string): Array<EventListener> {
+		const listeners = this.events.get(event);
+		return listeners ? Array.from(listeners) : [];
+	}
+}

--- a/packages/datastreams/src/utils/interfaces.ts
+++ b/packages/datastreams/src/utils/interfaces.ts
@@ -4,12 +4,18 @@
 export interface TokenResponse {
 	/**
 	 * WebSocket session identifier
+	 *
+	 * Note: the API returns this field as `wss-id` (hyphenated), so the
+	 * property must be accessed via bracket notation, e.g. `tokenPair['wss-id']`.
 	 */
-	wss_id: string;
+	'wss-id': string;
 	/**
 	 * Channel identifier
+	 *
+	 * Note: the API returns this field as `channel-id` (hyphenated), so the
+	 * property must be accessed via bracket notation, e.g. `tokenPair['channel-id']`.
 	 */
-	channel_id: string;
+	'channel-id': string;
 	/**
 	 * Authentication key for the connection
 	 */
@@ -21,17 +27,35 @@ export interface TokenResponse {
 }
 
 /**
+ * User reference embedded in channel details (e.g. `created_by`/`modified_by`).
+ */
+export interface ChannelUser {
+	/**
+	 * Catalyst user's unique ZUID
+	 */
+	zuid: string;
+	/**
+	 * Email address of the user
+	 */
+	email_id: string;
+	/**
+	 * Type of the user (e.g. "admin", "user")
+	 */
+	user_type: string;
+}
+
+/**
  * Individual channel information.
  */
 export interface ChannelDetails {
 	/**
 	 * Parent channel ID
 	 */
-	parentId: number;
+	parentId: string;
 	/**
 	 * Unique channel identifier
 	 */
-	id: number;
+	id: string;
 	/**
 	 * Channel name
 	 */
@@ -41,21 +65,21 @@ export interface ChannelDetails {
 	 */
 	service: string;
 	/**
-	 * ID of user who created the channel
+	 * User who created the channel
 	 */
-	created_by: number;
+	created_by: ChannelUser;
 	/**
-	 * ID of user who last modified the channel
+	 * User who last modified the channel
 	 */
-	modified_by: number;
+	modified_by: ChannelUser;
 	/**
-	 * Timestamp when channel was created
+	 * Formatted date string of when the channel was created
 	 */
-	created_time: number;
+	created_time: string;
 	/**
-	 * Timestamp when channel was last modified
+	 * Formatted date string of when the channel was last modified
 	 */
-	modified_time: number;
+	modified_time: string;
 	/**
 	 * Project ID this channel belongs to
 	 */
@@ -76,6 +100,10 @@ export interface ChannelDetails {
 	 * Channel status (e.g., "open")
 	 */
 	status: string;
+	/**
+	 * Data retention period configured for the channel
+	 */
+	retention: number;
 }
 
 /**

--- a/packages/datastreams/src/utils/interfaces.ts
+++ b/packages/datastreams/src/utils/interfaces.ts
@@ -1,0 +1,248 @@
+/**
+ * Token response when getting token pair for datastream channel authentication.
+ */
+export interface TokenResponse {
+	/**
+	 * WebSocket session identifier
+	 */
+	wss_id: string;
+	/**
+	 * Channel identifier
+	 */
+	channel_id: string;
+	/**
+	 * Authentication key for the connection
+	 */
+	key: string;
+	/**
+	 * WebSocket URL for connection
+	 */
+	url: string;
+}
+
+/**
+ * Individual channel information.
+ */
+export interface ChannelDetails {
+	/**
+	 * Parent channel ID
+	 */
+	parentId: number;
+	/**
+	 * Unique channel identifier
+	 */
+	id: number;
+	/**
+	 * Channel name
+	 */
+	name: string;
+	/**
+	 * Service type (typically "catalyst")
+	 */
+	service: string;
+	/**
+	 * ID of user who created the channel
+	 */
+	created_by: number;
+	/**
+	 * ID of user who last modified the channel
+	 */
+	modified_by: number;
+	/**
+	 * Timestamp when channel was created
+	 */
+	created_time: number;
+	/**
+	 * Timestamp when channel was last modified
+	 */
+	modified_time: number;
+	/**
+	 * Project ID this channel belongs to
+	 */
+	project_id: number;
+	/**
+	 * Control type for the channel
+	 */
+	control_type: number;
+	/**
+	 * Comma-separated control IDs
+	 */
+	control_ids: string;
+	/**
+	 * Source information
+	 */
+	source: string;
+	/**
+	 * Channel status (e.g., "open")
+	 */
+	status: string;
+}
+
+/**
+ * Channel live count response.
+ */
+export interface ChannelLiveCountResponse {
+	/**
+	 * Number of active connections to the channel
+	 */
+	connections: number;
+}
+
+/**
+ * Publish data response.
+ */
+export interface PublishDataResponse {
+	/**
+	 * Success message or response data
+	 */
+	message?: string;
+	/**
+	 * Additional fields can be included as key-value pairs
+	 */
+	[key: string]: unknown;
+}
+
+/**
+ * Datastream API error response.
+ */
+export interface DatastreamErrorResponse {
+	/**
+	 * Error code
+	 */
+	code: string;
+	/**
+	 * Error message
+	 */
+	message: string;
+	/**
+	 * Additional error details
+	 */
+	details?: unknown;
+}
+
+/**
+ * Type aliases for API responses
+ */
+export type GetChannelResponse = ChannelDetails;
+export type GetAllChannelsResponse = Array<ChannelDetails>;
+
+/**
+ * Response type for general API calls
+ */
+export type DatastreamsResponse = Record<string, unknown>;
+
+/**
+ * Payload for token pair request.
+ */
+export interface TokenPairPayload {
+	/**
+	 * Application user ID
+	 */
+	app_user_id?: string;
+	/**
+	 * Connection name
+	 */
+	connection_name?: string;
+}
+
+/**
+ * Payload for publishing data to a channel.
+ */
+export interface PublishDataPayload {
+	/**
+	 * The data to be published
+	 */
+	data: string;
+}
+
+/**
+ * Constants for channel status values
+ */
+export const ChannelStatus = {
+	OPEN: 'open',
+	CLOSED: 'closed',
+	ACTIVE: 'active',
+	INACTIVE: 'inactive'
+} as const;
+
+/**
+ * Constants for service type values
+ */
+export const ServiceType = {
+	CATALYST: 'catalyst'
+} as const;
+
+/**
+ * Generic API response wrapper.
+ */
+export interface ApiResponse<T = unknown> {
+	/**
+	 * Response status
+	 */
+	status: string;
+	/**
+	 * Response data
+	 */
+	data?: T;
+	/**
+	 * Error information (if any)
+	 */
+	error?: DatastreamErrorResponse;
+	/**
+	 * Response timestamp
+	 */
+	timestamp?: string;
+}
+
+export interface DataStreamsConfig {
+	url: string;
+	zuid: string;
+	key: string;
+	enableLogging?: boolean;
+}
+
+export interface WebSocketLike {
+	readyState: number;
+	OPEN: number;
+	CLOSED: number;
+	CONNECTING: number;
+	CLOSING: number;
+	send(data: string): void;
+	close(code?: number, reason?: string): void;
+	on(event: string, listener: (...args: Array<unknown>) => void): void;
+	removeAllListeners?(event?: string): void;
+}
+
+export interface DataStreamMessageEvent {
+	data?: string; // data
+	streamingId?: string;
+	url?: string;
+	method?: string;
+}
+
+export interface CustomEvent {
+	code?: number;
+	message?: string;
+	error?: string;
+}
+
+export interface SubscribePayload {
+	type: string;
+	value: string;
+	streamingId: string | number;
+}
+
+export interface AckPayload {
+	type: string;
+	streamingId: string | number;
+}
+
+export interface UnsubscribePayload {
+	type: string;
+	value: string;
+}
+
+export interface ServerPingPayload {
+	type: string;
+	value: string;
+}

--- a/packages/datastreams/src/utils/validators.ts
+++ b/packages/datastreams/src/utils/validators.ts
@@ -1,18 +1,68 @@
 import { CatalystDataStreamError } from './errors';
 
 /**
- * Allowed hostname pattern (RFC 1123). Only alphanumeric characters, hyphens,
- * and dots are permitted between labels.
+ * Fixed allow-list of the only DataStreams (DMS) hostnames the SDK is permitted
+ * to connect to, one per supported Zoho/Catalyst data center. This is a closed,
+ * SDK-controlled set (not derived from caller/user input), so validating against
+ * it -- rather than merely checking the *shape* of an arbitrary hostname --
+ * prevents the connection from ever being redirected to an unintended
+ * internal/external endpoint (SSRF, CWE-918).
  */
-const HOSTNAME_PATTERN =
-	/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+const ALLOWED_DATASTREAM_HOSTS = new Set(
+	[
+		// US
+		'us4-dms.zoho.com',
+		'us3-dms.zoho.com',
+		// US PRE
+		'predms.zoho.com',
+		// EU
+		'eu1-dms.zoho.eu',
+		'eu2-dms.zoho.eu',
+		// IN
+		'in2-dms.zoho.in',
+		'in1-dms.zoho.in',
+		// AU
+		'au1-dms.zoho.com.au',
+		'au2-dms.zoho.com.au',
+		// CN
+		'cn2-dms.zoho.com.cn',
+		'cn3-dms.zoho.com.cn',
+		// JP
+		'jp1-dms.zoho.jp',
+		'jp2-dms.zoho.jp',
+		// CA
+		'ca1-dms.zohocloud.ca',
+		'ca2-dms.zohocloud.ca',
+		// UK
+		'uk1-dms.zoho.uk',
+		'uk2-dms.zoho.uk',
+		// LOCAL
+		'local-dms.localzoho.com',
+		'ct2-dms.localzoho.com',
+		// LOCAL PRE
+		'predms.localzoho.com',
+		'ct2-predms.localzoho.com',
+		// SA
+		'sa1-dms.zoho.sa',
+		'sa2-dms.zoho.sa',
+		// UAE
+		'uae1-dms.zoho.ae',
+		'uae2-dms.zoho.ae'
+	].map((host) => host.toLowerCase())
+);
 
 /**
- * Validates that a value is safe to interpolate into a WebSocket URL
- * authority component.
+ * Validates that a value is one of the known, allow-listed DataStreams (DMS)
+ * hostnames before it is used to open a connection. Any host that is not an
+ * exact match for an entry in {@link ALLOWED_DATASTREAM_HOSTS} is rejected,
+ * regardless of whether it is otherwise a syntactically valid hostname --
+ * this closes the request-forgery (SSRF) gap where a syntactically valid but
+ * unintended/internal host (e.g. a metadata endpoint or private IP) could
+ * otherwise be used to redirect the connection.
  * @param host - The DataStreams host to validate.
  * @param name - The name of the value being validated, used in error messages.
- * @throws {CatalystDataStreamError} when the host is missing, empty, or contains disallowed characters.
+ * @returns The validated host, normalized to lowercase.
+ * @throws {CatalystDataStreamError} when the host is missing, empty, or not an allow-listed DataStreams host.
  */
 export function assertValidHost(host: unknown, name: string): string {
 	if (typeof host !== 'string' || host === '') {
@@ -22,17 +72,16 @@ export function assertValidHost(host: unknown, name: string): string {
 			host
 		);
 	}
-	const match = HOSTNAME_PATTERN.exec(host);
-	if (!match) {
+	const normalizedHost = host.toLowerCase();
+	if (!ALLOWED_DATASTREAM_HOSTS.has(normalizedHost)) {
 		throw new CatalystDataStreamError(
 			'INVALID_ARGUMENT',
-			`Value provided for ${name} contains invalid characters. Only alphanumeric ` +
-				'characters, hyphens, and dots are allowed.',
+			`Value provided for ${name} is not a recognized DataStreams host.`,
 			host
 		);
 	}
 
-	return match[0];
+	return normalizedHost;
 }
 
 /**

--- a/packages/datastreams/src/utils/validators.ts
+++ b/packages/datastreams/src/utils/validators.ts
@@ -45,9 +45,14 @@ export function assertValidHost(host: unknown, name: string): asserts host is st
  * an authority-injection (SSRF) bypass.
  * @param wsUrl - The constructed WebSocket URL to verify.
  * @param expectedHost - The host that `wsUrl` is expected to resolve to.
+ * @returns The parsed, verified `URL` instance. Callers should use this
+ * returned object (e.g. its `href`) as the actual value passed to the
+ * WebSocket constructor, rather than the original `wsUrl` string, so that
+ * the connection is opened from a value that has been demonstrably parsed
+ * and validated rather than merely checked and discarded.
  * @throws {CatalystDataStreamError} when the URL does not match the expected authority.
  */
-export function assertValidWebSocketUrl(wsUrl: string, expectedHost: string): void {
+export function assertValidWebSocketUrl(wsUrl: string, expectedHost: string): URL {
 	let parsed: URL;
 	try {
 		parsed = new URL(wsUrl);
@@ -70,4 +75,5 @@ export function assertValidWebSocketUrl(wsUrl: string, expectedHost: string): vo
 			wsUrl
 		);
 	}
+	return parsed;
 }

--- a/packages/datastreams/src/utils/validators.ts
+++ b/packages/datastreams/src/utils/validators.ts
@@ -2,24 +2,19 @@ import { CatalystDataStreamError } from './errors';
 
 /**
  * Allowed hostname pattern (RFC 1123). Only alphanumeric characters, hyphens,
- * and dots are permitted between labels. Delimiters that carry special
- * meaning in a URL authority (`/`, `\`, `#`, `?`, `@`, `:`, `%`, whitespace,
- * unicode, etc.) are rejected.
+ * and dots are permitted between labels.
  */
 const HOSTNAME_PATTERN =
 	/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 /**
  * Validates that a value is safe to interpolate into a WebSocket URL
- * authority component. This guards against authority-injection payloads
- * (e.g. `host/#`, `host@attacker.example`, `host:1234`) that would otherwise
- * cause the DataStreams connection - and its auth key - to be sent to an
- * attacker-controlled origin (SSRF).
+ * authority component.
  * @param host - The DataStreams host to validate.
  * @param name - The name of the value being validated, used in error messages.
  * @throws {CatalystDataStreamError} when the host is missing, empty, or contains disallowed characters.
  */
-export function assertValidHost(host: unknown, name: string): asserts host is string {
+export function assertValidHost(host: unknown, name: string): string {
 	if (typeof host !== 'string' || host === '') {
 		throw new CatalystDataStreamError(
 			'INVALID_ARGUMENT',
@@ -27,7 +22,8 @@ export function assertValidHost(host: unknown, name: string): asserts host is st
 			host
 		);
 	}
-	if (!HOSTNAME_PATTERN.test(host)) {
+	const match = HOSTNAME_PATTERN.exec(host);
+	if (!match) {
 		throw new CatalystDataStreamError(
 			'INVALID_ARGUMENT',
 			`Value provided for ${name} contains invalid characters. Only alphanumeric ` +
@@ -35,21 +31,16 @@ export function assertValidHost(host: unknown, name: string): asserts host is st
 			host
 		);
 	}
+
+	return match[0];
 }
 
 /**
- * Verifies that a constructed DataStreams WebSocket URL resolves to the
- * expected `wss:` origin for the given host. This is a defense-in-depth
- * check performed immediately before the URL is used to open a connection,
- * so that any future change to URL construction cannot silently reintroduce
- * an authority-injection (SSRF) bypass.
+ * Verifies that a constructed DataStreams WebSocket URL
+
  * @param wsUrl - The constructed WebSocket URL to verify.
  * @param expectedHost - The host that `wsUrl` is expected to resolve to.
- * @returns The parsed, verified `URL` instance. Callers should use this
- * returned object (e.g. its `href`) as the actual value passed to the
- * WebSocket constructor, rather than the original `wsUrl` string, so that
- * the connection is opened from a value that has been demonstrably parsed
- * and validated rather than merely checked and discarded.
+ * @returns The parsed, verified `URL` instance.
  * @throws {CatalystDataStreamError} when the URL does not match the expected authority.
  */
 export function assertValidWebSocketUrl(wsUrl: string, expectedHost: string): URL {

--- a/packages/datastreams/src/utils/validators.ts
+++ b/packages/datastreams/src/utils/validators.ts
@@ -1,0 +1,73 @@
+import { CatalystDataStreamError } from './errors';
+
+/**
+ * Allowed hostname pattern (RFC 1123). Only alphanumeric characters, hyphens,
+ * and dots are permitted between labels. Delimiters that carry special
+ * meaning in a URL authority (`/`, `\`, `#`, `?`, `@`, `:`, `%`, whitespace,
+ * unicode, etc.) are rejected.
+ */
+const HOSTNAME_PATTERN =
+	/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+/**
+ * Validates that a value is safe to interpolate into a WebSocket URL
+ * authority component. This guards against authority-injection payloads
+ * (e.g. `host/#`, `host@attacker.example`, `host:1234`) that would otherwise
+ * cause the DataStreams connection - and its auth key - to be sent to an
+ * attacker-controlled origin (SSRF).
+ * @param host - The DataStreams host to validate.
+ * @param name - The name of the value being validated, used in error messages.
+ * @throws {CatalystDataStreamError} when the host is missing, empty, or contains disallowed characters.
+ */
+export function assertValidHost(host: unknown, name: string): asserts host is string {
+	if (typeof host !== 'string' || host === '') {
+		throw new CatalystDataStreamError(
+			'INVALID_ARGUMENT',
+			`Value provided for ${name} must be a non-empty String.`,
+			host
+		);
+	}
+	if (!HOSTNAME_PATTERN.test(host)) {
+		throw new CatalystDataStreamError(
+			'INVALID_ARGUMENT',
+			`Value provided for ${name} contains invalid characters. Only alphanumeric ` +
+				'characters, hyphens, and dots are allowed.',
+			host
+		);
+	}
+}
+
+/**
+ * Verifies that a constructed DataStreams WebSocket URL resolves to the
+ * expected `wss:` origin for the given host. This is a defense-in-depth
+ * check performed immediately before the URL is used to open a connection,
+ * so that any future change to URL construction cannot silently reintroduce
+ * an authority-injection (SSRF) bypass.
+ * @param wsUrl - The constructed WebSocket URL to verify.
+ * @param expectedHost - The host that `wsUrl` is expected to resolve to.
+ * @throws {CatalystDataStreamError} when the URL does not match the expected authority.
+ */
+export function assertValidWebSocketUrl(wsUrl: string, expectedHost: string): void {
+	let parsed: URL;
+	try {
+		parsed = new URL(wsUrl);
+	} catch {
+		throw new CatalystDataStreamError(
+			'INVALID_ARGUMENT',
+			'Unable to construct a valid WebSocket URL for the given host.',
+			wsUrl
+		);
+	}
+	if (
+		parsed.protocol !== 'wss:' ||
+		parsed.username !== '' ||
+		parsed.password !== '' ||
+		parsed.hostname.toLowerCase() !== expectedHost.toLowerCase()
+	) {
+		throw new CatalystDataStreamError(
+			'INVALID_ARGUMENT',
+			'The constructed WebSocket URL does not match the expected DataStreams host.',
+			wsUrl
+		);
+	}
+}

--- a/packages/datastreams/src/web-socket.ts
+++ b/packages/datastreams/src/web-socket.ts
@@ -84,13 +84,12 @@ export class DataStreamsWebSocket extends EventEmitter {
 		isNonEmptyString(config.url, 'url', true);
 		isNonEmptyString(config.key, 'key', true);
 		isNonEmptyString(config.zuid, 'zuid', true);
-		// Prevent authority-injection (SSRF) via a crafted host containing
-		// `/`, `@`, `:`, etc. before it is interpolated into the WebSocket URL.
-		assertValidHost(config.url, 'url');
+		const validatedUrl = assertValidHost(config.url, 'url');
 
 		this.config = {
 			enableLogging: config.enableLogging || false,
-			...config
+			...config,
+			url: validatedUrl
 		};
 
 		this.url = this.config.url;
@@ -288,8 +287,9 @@ export class DataStreamsWebSocket extends EventEmitter {
 					const msg = jsonData[0].msg as Record<string, string>;
 					const newHost = msg[msg.primarydc];
 
+					let validatedHost: string;
 					try {
-						assertValidHost(newHost, 'url');
+						validatedHost = assertValidHost(newHost, 'url');
 					} catch (validationError) {
 						const errorEvent: CustomEvent = {
 							code: 1007,
@@ -299,7 +299,7 @@ export class DataStreamsWebSocket extends EventEmitter {
 						break;
 					}
 
-					this.url = newHost;
+					this.url = validatedHost;
 
 					if (this.conn && this.conn.readyState === this.conn.OPEN) {
 						this.conn.close(

--- a/packages/datastreams/src/web-socket.ts
+++ b/packages/datastreams/src/web-socket.ts
@@ -1,0 +1,723 @@
+/**
+ * Enhanced WebSocket DataStreams Client
+ *
+ * A modern TypeScript implementation of the DataStreams WebSocket client
+ * with improved error handling, type safety, and cross-platform support.
+ */
+
+import { isNonEmptyString, ObjectHasProperties } from '@zcatalyst/utils';
+
+import { MessageType } from './utils/enum';
+import { EventEmitter } from './utils/event-emitter';
+import {
+	AckPayload,
+	CustomEvent,
+	DataStreamMessageEvent,
+	DataStreamsConfig,
+	ServerPingPayload,
+	SubscribePayload,
+	UnsubscribePayload,
+	WebSocketLike
+} from './utils/interfaces';
+import { assertValidHost, assertValidWebSocketUrl } from './utils/validators';
+
+/**
+ * Enhanced DataStreams WebSocket client with modern TypeScript features
+ */
+export class DataStreamsWebSocket extends EventEmitter {
+	// Configuration
+	private readonly config: DataStreamsConfig;
+	private readonly prdValue = 'CY';
+	private readonly path = '/wsconnect';
+
+	// Connection properties
+	private url: string;
+	private keyValue: string;
+	private zuidValue: string;
+	private sid = ''; // Session ID for reconnection
+	private uid = ''; // User ID for reconnection
+	private finalUrl = ''; // Complete WebSocket URL
+	private conn: WebSocketLike | null = null; // WebSocket instance
+
+	// State management
+	private isOpen = false;
+	private ackSent = false;
+	private reconnect = false;
+	private prevStreamingId = '';
+	private fallbackConnectionAttempts = 0;
+
+	// Intervals and timeouts
+	private pingInterval: NodeJS.Timeout | null = null;
+	private reconnectInterval: NodeJS.Timeout | null = null;
+	private pingServerInterval: NodeJS.Timeout | null = null;
+
+	// Payload templates
+	private subscribePayload: SubscribePayload = {
+		type: 'con',
+		value: 'subscribe',
+		streamingId: ''
+	};
+
+	private ackPayload: AckPayload = {
+		type: 'ack',
+		streamingId: ''
+	};
+
+	private readonly unsubscribePayload: UnsubscribePayload = {
+		type: 'con',
+		value: 'unsubscribe'
+	};
+
+	private readonly serverPingPayload: ServerPingPayload = {
+		type: 'con',
+		value: 'ping'
+	};
+
+	constructor(config: DataStreamsConfig) {
+		super();
+
+		ObjectHasProperties(
+			config as unknown as Record<string, unknown>,
+			['url', 'key', 'zuid'],
+			'DataStreamsConfig'
+		);
+		isNonEmptyString(config.url, 'url', true);
+		isNonEmptyString(config.key, 'key', true);
+		isNonEmptyString(config.zuid, 'zuid', true);
+		// Prevent authority-injection (SSRF) via a crafted host containing
+		// `/`, `@`, `:`, etc. before it is interpolated into the WebSocket URL.
+		assertValidHost(config.url, 'url');
+
+		this.config = {
+			enableLogging: config.enableLogging || false,
+			...config
+		};
+
+		this.url = this.config.url;
+		this.keyValue = this.config.key;
+		this.zuidValue = this.config.zuid;
+
+		this.finalUrl = `wss://${this.url}${this.path}?prd=${this.prdValue}&zuid=${this.zuidValue}&key=${this.keyValue}`;
+
+		this.createWebSocketConnection();
+	}
+
+	/**
+	 * Create WebSocket connection with cross-platform support
+	 */
+	/**
+	 * Create WebSocket connection with cross-platform support
+	 */
+	private async createWebSocketConnection(): Promise<void> {
+		try {
+			assertValidWebSocketUrl(this.finalUrl, this.url);
+
+			let WebSocketConstructor: new (url: string) => WebSocketLike;
+
+			// Check if we're in a browser environment
+			if (typeof window !== 'undefined' && window.WebSocket) {
+				// Browser environment
+				WebSocketConstructor = window.WebSocket as unknown as new (
+					url: string
+				) => WebSocketLike;
+			} else if (typeof global !== 'undefined') {
+				// Node.js environment
+				try {
+					const ws = await import('ws');
+					WebSocketConstructor = ws.default as unknown as new (
+						url: string
+					) => WebSocketLike;
+				} catch (importError) {
+					// Fallback to require for older environments
+					try {
+						const WebSocketModule = require('ws');
+						WebSocketConstructor = WebSocketModule;
+					} catch (requireError) {
+						throw new Error(
+							'WebSocket implementation not available. Please ensure you are running in a browser or have the "ws" package installed for Node.js'
+						);
+					}
+				}
+			} else {
+				// Neither browser nor Node.js environment detected
+				throw new Error('WebSocket not available in this environment');
+			}
+
+			this.conn = new WebSocketConstructor(this.finalUrl);
+			this.setupEventHandlers();
+		} catch (error) {
+			const errorMessage =
+				error instanceof Error
+					? error.message
+					: 'Unknown error creating WebSocket connection';
+			this.log(`Error creating WebSocket connection: ${errorMessage}`);
+
+			const customError: CustomEvent = {
+				code: 1006,
+				message: `Failed to create WebSocket connection: ${errorMessage}`
+			};
+
+			this.emit('error', customError);
+		}
+	}
+
+	/**
+	 * Setup WebSocket event handlers for both browser and Node.js environments
+	 */
+	private setupEventHandlers(): void {
+		if (!this.conn) return;
+
+		// Check if this is a browser WebSocket (has onopen property) or Node.js WebSocket (has on method)
+		if (typeof this.conn.on === 'function') {
+			// Node.js WebSocket (ws package) - uses EventEmitter pattern
+			// In Node.js ws package, the 'message' event passes raw data (string/Buffer)
+			this.conn.on('open', (event) => this.handleWebSocketOpenEvent(event));
+			this.conn.on('close', (event) => this.handleWebSocketCloseEvent(event));
+			this.conn.on('message', (data) => this.handleDMSEvents(data));
+			this.conn.on('error', (event) => this.handleWebSocketErrorEvent(event));
+		} else {
+			// Browser WebSocket - uses direct event handler assignment
+			// In browser, the 'message' event has a MessageEvent with .data property
+			const browserWs = this.conn as unknown as WebSocket;
+
+			browserWs.onopen = (event) => this.handleWebSocketOpenEvent(event);
+			browserWs.onclose = (event) => this.handleWebSocketCloseEvent(event);
+			browserWs.onmessage = (event) => this.handleDMSEvents(event.data);
+			browserWs.onerror = (event) => this.handleWebSocketErrorEvent(event);
+		}
+	}
+
+	/**
+	 * Log messages if logging is enabled
+	 */
+	private log(message: string): void {
+		if (this.config.enableLogging) {
+			// eslint-disable-next-line no-console
+			console.log(`[DataStreams] ${message}`);
+		}
+	}
+
+	/**
+	 * Handle WebSocket open event
+	 */
+	private handleWebSocketOpenEvent(event: unknown): void {
+		this.log('WebSocket connection opened');
+
+		if (this.reconnect) {
+			this.log('Reconnection event successful!');
+
+			if (this.conn && this.conn.readyState === this.conn.OPEN) {
+				this.log(`Subscribe payload: ${JSON.stringify(this.subscribePayload)}`);
+				if (this.ackSent) {
+					this.subscribePayload.streamingId = '-2';
+					this.conn.send(JSON.stringify(this.subscribePayload));
+				}
+			}
+
+			// Subsequent ping and reconnection will be handled here
+			this.startPing();
+			this.startPingToServer();
+			this.startCloseAndReconnect();
+			this.reconnect = false;
+		}
+
+		this.isOpen = true;
+	}
+
+	/**
+	 * Handle WebSocket close event
+	 */
+	private handleWebSocketCloseEvent(event: unknown): void {
+		// When connection is closed by user / due to other interference
+		this.emit('close', event);
+		this.clearPingInterval();
+		this.clearReconnectInterval();
+		this.isOpen = false;
+
+		// else will be closed via code for reconnect operation
+	}
+
+	/**
+	 * Handle WebSocket error event
+	 */
+	private handleWebSocketErrorEvent(event: unknown): void {
+		this.log(`WebSocket error: ${JSON.stringify(event)}`);
+		this.emit('error', event);
+	}
+
+	/**
+	 * Handle DataStreams events - main message processing logic
+	 */
+	private handleDMSEvents(event: unknown): void {
+		/**
+		 * ALL Catalyst connection and data events will be handled here
+		 * 1. Connection based on mtype key
+		 * 2. Data events (catalyst) will be handled in data key
+		 *
+		 * mtypes:
+		 * -1 -> to connect using RO/new RW url during switch/issue in DMS servers
+		 * -2 -> Param key is missing in connection
+		 * -5 -> Authentication failed from service (catalyst) team
+		 * -11 -> Current session gets expired after 30 mins; should reconnect with sid and uid
+		 * 0 -> Connection established after successful authentication
+		 * 660 -> Connection is blocked due DDOS attack from zoho side
+		 * 650 -> Actual service data events will be handled here
+		 * 670 -> When service (catalyst) server is not reachable
+		 */
+
+		const actualData = event;
+
+		if (!actualData || actualData.toString() === '') {
+			// Handle pong event
+			const customEvent = { message: 'Pong received' };
+			this.emit('pong', customEvent);
+			return;
+		}
+
+		try {
+			const jsonData = JSON.parse(actualData.toString()) as Array<Record<string, unknown>>;
+			const mtype = jsonData[0]?.mtype as string;
+
+			switch (mtype) {
+				case MessageType.SWITCH_URL: {
+					const msg = jsonData[0].msg as Record<string, string>;
+					const newHost = msg[msg.primarydc];
+
+					try {
+						assertValidHost(newHost, 'url');
+					} catch (validationError) {
+						const errorEvent: CustomEvent = {
+							code: 1007,
+							message: 'Received an invalid host in the switch-url message.'
+						};
+						this.emit('error', errorEvent);
+						break;
+					}
+
+					this.url = newHost;
+
+					if (this.conn && this.conn.readyState === this.conn.OPEN) {
+						this.conn.close(
+							1000,
+							'Closing this connection and opening new connection!'
+						);
+						this.makeNewConnection();
+					}
+					break;
+				}
+
+				case MessageType.MISSING_KEY: {
+					// Mandatory param 'key' is missing
+					const errorEvent: CustomEvent = {
+						code: 1014,
+						message: 'Mandatory param key is missing'
+					};
+					this.emit('error', errorEvent);
+					break;
+				}
+
+				case MessageType.AUTH_FAILED: {
+					/**
+					 * 1. Authentication failed from catalyst side
+					 * 2. DMS cannot reach Catalyst server, on timeout this event will be given
+					 * User should generate new token pair
+					 */
+					this.log('-5 triggered');
+					const errorEvent: CustomEvent = {
+						code: 3000,
+						message:
+							'Authentication failed, please generate valid credentials and try again after some time!'
+					};
+					this.emit('error', errorEvent);
+					break;
+				}
+
+				case MessageType.SESSION_EXPIRED: {
+					/**
+					 * Current connections expired in 30 mins
+					 * New connections should be made with new credentials
+					 * Solution: We have to end the current connection in 25 mins, open a wss connection with sid and uid
+					 *
+					 * Key-mismatch fallback: when a SESSION_EXPIRED frame arrives with a reason
+					 * containing "key_mismatch" (previous connection still alive), retry
+					 * connect() once before surfacing the error to on_error.
+					 */
+					const isKeyMismatch = String(jsonData[0]?.reason ?? '').includes(
+						'key_mismatch'
+					);
+
+					const invalidRequestFailure = String(jsonData[0]?.reason ?? '').includes(
+						'Invalid Request'
+					);
+
+					const isConnectionAlive = isKeyMismatch || invalidRequestFailure;
+
+					if (isConnectionAlive && this.fallbackConnectionAttempts === 0) {
+						this.fallbackConnectionAttempts += 1;
+						this.log(
+							'SESSION_EXPIRED with key_mismatch reason; previous connection still alive, retrying connect() once'
+						);
+						this.createWebSocketConnection();
+					} else {
+						const errorEvent: CustomEvent = {
+							code: 1000,
+							message:
+								'Current session will be closed. New connection to be established.'
+						};
+						this.emit('error', errorEvent);
+						this.log(
+							'WebSocket connection got expired. Please generate new credentials to connect again'
+						);
+					}
+					break;
+				}
+
+				case MessageType.AUTH_SUCCESS: {
+					/**
+					 * Authentication is success from catalyst
+					 * Subscribe request has to be made from here to actually receive data from channel
+					 * 1. sid and uid are stored
+					 * 2. authentication success event will be sent to open event
+					 * 3. Ping will be done for every 15 seconds
+					 */
+					const msg = jsonData[0].msg as { sid: string; uid: string };
+					this.sid = msg.sid;
+					this.uid = msg.uid;
+
+					const openEvent: CustomEvent = {
+						code: 200,
+						message:
+							'Streams connection established, please subscribe with appropriate subscribe type to start streaming.'
+					};
+					this.emit('open', openEvent);
+
+					// First time ping and reconnection will be called here
+					this.startPing();
+					this.startPingToServer();
+					// this.startCloseAndReconnect(); // Uncomment if needed
+					break;
+				}
+
+				case MessageType.BLOCKED: {
+					// Connection is blocked from DMS due to DOS
+					const customEvent: CustomEvent = {
+						code: 1013,
+						message: 'Data streams connection is blocked! Please contact support!'
+					};
+					this.emit('error', customEvent);
+					break;
+				}
+
+				case MessageType.DATA_EVENT: {
+					// Actual data event from catalyst will be handled here
+					this.handleDataEvents(jsonData);
+					break;
+				}
+
+				case MessageType.SERVER_DOWN: {
+					// When catalyst app server is down - Retry connection in 5 mins
+					const customEvent: CustomEvent = {
+						code: 1011,
+						message: 'Internal server error. Please retry after a minute'
+					};
+					this.log('-> 670 server is down');
+					this.startPingToServer();
+					this.emit('error', customEvent);
+					break;
+				}
+
+				default:
+					this.log(`Unknown message type: ${mtype}`);
+					break;
+			}
+		} catch (error) {
+			this.log(
+				`Error parsing WebSocket message: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
+		}
+	}
+
+	/**
+	 * Check if WebSocket is open and ready
+	 */
+	private isWebSocketOpen(): boolean {
+		return this.conn !== null && this.conn.readyState === this.conn.OPEN;
+	}
+
+	/**
+	 * Handle data events (message type 650)
+	 */
+	private handleDataEvents(jsonData: Array<Record<string, unknown>>): void {
+		for (let i = 0; i < jsonData.length; i++) {
+			const msg = jsonData[i].msg as Record<string, unknown>;
+			const data = msg.data as {
+				streamingId: string;
+				data?: unknown;
+				url?: string;
+				method?: string;
+				value?: string;
+				code?: string;
+			};
+
+			if (this.prevStreamingId === data.streamingId && this.ackSent) {
+				// Skipping if streaming id already processed
+				this.log(`prev :: ${this.prevStreamingId}, current :: ${data.streamingId}`);
+				this.ackPayload.streamingId = this.prevStreamingId;
+				if (this.isWebSocketOpen()) {
+					this.conn!.send(JSON.stringify(this.ackPayload));
+				}
+			} else {
+				const operation = msg.opr as string;
+
+				if (operation === 'event') {
+					this.ackSent = false;
+					this.prevStreamingId = data.streamingId;
+					this.ackPayload.streamingId = data.streamingId;
+
+					const customEvent: DataStreamMessageEvent = {
+						data: data.data as string,
+						streamingId: data.streamingId
+					};
+					this.emit('message', customEvent);
+				} else if (operation === 'api') {
+					this.ackSent = false;
+					this.ackPayload.streamingId = data.streamingId;
+					this.prevStreamingId = data.streamingId;
+
+					const customEvent: DataStreamMessageEvent = {
+						streamingId: data.streamingId,
+						url: data.url,
+						method: data.method
+					};
+					this.emit('message', customEvent);
+				} else if (operation === 'connect') {
+					/**
+					 * 1. clearing ping to server on interval process
+					 * 2. Sending ack to start streaming
+					 */
+					if (this.ackSent && this.isWebSocketOpen()) {
+						const ackPayload = { ...this.ackPayload };
+						ackPayload.streamingId = '-2';
+						this.log('Ack payload for pong');
+						this.conn!.send(JSON.stringify(ackPayload));
+					}
+				} else if (operation === 'error') {
+					const errorEvent: CustomEvent = {
+						error: data.value as string
+					};
+					if (data.code === 'e3' || data.code === 'e5') {
+						errorEvent.error = 'Subscription failed. Invalid subscription type.';
+					}
+					this.emit('error', errorEvent);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Create new WebSocket connection for reconnection
+	 */
+	private makeNewConnection(): void {
+		if (this.sid && this.uid) {
+			this.finalUrl = `wss://${this.url}${this.path}?key=${this.keyValue}&i=${this.sid}&c=${this.uid}`;
+			this.log(`New connection URL: ${this.finalUrl}`);
+
+			this.createWebSocketConnection();
+		}
+	}
+
+	/**
+	 * Clear ping interval
+	 */
+	private clearPingInterval(): void {
+		if (this.pingInterval) {
+			clearInterval(this.pingInterval);
+			this.pingInterval = null;
+		}
+	}
+
+	/**
+	 * Clear reconnect interval
+	 */
+	private clearReconnectInterval(): void {
+		if (this.reconnectInterval) {
+			clearTimeout(this.reconnectInterval);
+			this.reconnectInterval = null;
+		}
+	}
+
+	/**
+	 * Clear ping server interval
+	 */
+	private clearPingServerInterval(): void {
+		if (this.pingServerInterval) {
+			clearInterval(this.pingServerInterval);
+			this.pingServerInterval = null;
+		}
+	}
+
+	/**
+	 * Start ping interval (every 15 seconds)
+	 */
+	private startPing(): void {
+		this.clearPingInterval();
+
+		this.pingInterval = setInterval(() => {
+			if (this.conn && this.conn.readyState === this.conn.OPEN) {
+				this.log('-');
+				this.conn.send('-');
+			} else {
+				this.log('Clearing ping interval');
+				this.clearPingInterval();
+			}
+		}, 15000); // 15 seconds
+	}
+
+	/**
+	 * Start ping to server (when server is down)
+	 */
+	private startPingToServer(): void {
+		this.clearPingServerInterval();
+
+		this.pingServerInterval = setInterval(() => {
+			if (this.conn && this.conn.readyState === this.conn.OPEN) {
+				this.log('Ping server to reconnect');
+				this.conn.send(JSON.stringify(this.serverPingPayload));
+			} else {
+				this.log('Clearing ping server interval');
+				this.clearPingServerInterval();
+			}
+		}, 60000); // 60 seconds
+	}
+
+	/**
+	 * Start close and reconnect timer (every 27 minutes)
+	 */
+	private startCloseAndReconnect(): void {
+		this.clearReconnectInterval();
+
+		this.reconnectInterval = setTimeout(
+			() => {
+				if (this.conn && this.conn.readyState === this.conn.OPEN) {
+					this.clearPingInterval();
+					this.clearReconnectInterval();
+					this.clearPingServerInterval();
+
+					this.log(
+						'Closing current connection and making new connection using sid and uid'
+					);
+					this.conn.close(1000, 'Closing this connection and opening new connection!');
+
+					setTimeout(() => {
+						this.reconnect = true;
+						this.makeNewConnection();
+					}, 50);
+				}
+			},
+			27 * 60 * 1000
+		); // 27 minutes - was 60*100*1000 in original (which would be 100 minutes)
+	}
+
+	// Public API methods
+
+	/**
+	 * Subscribe to a channel with specified type
+	 * @param subscribeType - live events/earliest available events/resume from previous left off/streaming id
+	 *                       { 0 - live event, -1 - earliest, -2 - resume, streaming id}
+	 */
+	subscribe(subscribeType: string = '0'): void {
+		if (subscribeType === undefined) {
+			throw new Error('Subscribe type is required');
+		}
+
+		this.subscribePayload.streamingId = subscribeType;
+
+		if (this.conn && this.conn.readyState === this.conn.OPEN) {
+			this.log(`Subscribing with payload: ${JSON.stringify(this.subscribePayload)}`);
+			this.conn.send(JSON.stringify(this.subscribePayload));
+		} else {
+			throw new Error('WebSocket connection is not open');
+		}
+	}
+
+	/**
+	 * Unsubscribe from channel
+	 */
+	unsubscribe(): void {
+		if (this.conn && this.conn.readyState === this.conn.OPEN) {
+			this.conn.send(JSON.stringify(this.unsubscribePayload));
+			this.log('Unsubscribed from channel');
+		} else {
+			throw new Error('WebSocket connection is not open');
+		}
+	}
+
+	/**
+	 * Send acknowledgement to receive next stream data if available
+	 */
+	sendAck(): void {
+		if (
+			this.conn &&
+			this.conn.readyState === this.conn.OPEN &&
+			this.ackPayload.streamingId !== ''
+		) {
+			this.conn.send(JSON.stringify(this.ackPayload));
+			this.ackSent = true;
+			this.log(`Sent ack for streaming ID: ${this.ackPayload.streamingId}`);
+		} else {
+			this.log('Cannot send ack: connection not open or no streaming ID');
+		}
+	}
+
+	/**
+	 * Close the WebSocket connection
+	 */
+	close(): void {
+		if (this.conn && this.conn.readyState === this.conn.OPEN) {
+			this.conn.close(1000, 'Closing connection intentionally');
+			this.log('WebSocket connection closed manually');
+		}
+
+		// Clean up intervals
+		this.clearPingInterval();
+		this.clearReconnectInterval();
+		this.clearPingServerInterval();
+	}
+
+	/**
+	 * Check if the connection is open
+	 */
+	isConnected(): boolean {
+		return this.conn !== null && this.conn.readyState === this.conn.OPEN && this.isOpen;
+	}
+
+	/**
+	 * Get current connection state
+	 */
+	getConnectionState(): string {
+		if (!this.conn) return 'disconnected';
+
+		switch (this.conn.readyState) {
+			case this.conn.CONNECTING:
+				return 'connecting';
+			case this.conn.OPEN:
+				return 'connected';
+			case this.conn.CLOSING:
+				return 'closing';
+			case this.conn.CLOSED:
+				return 'closed';
+			default:
+				return 'unknown';
+		}
+	}
+
+	/**
+	 * Get session information
+	 */
+	getSessionInfo(): { sid: string; uid: string } {
+		return {
+			sid: this.sid,
+			uid: this.uid
+		};
+	}
+}

--- a/packages/datastreams/src/web-socket.ts
+++ b/packages/datastreams/src/web-socket.ts
@@ -110,7 +110,12 @@ export class DataStreamsWebSocket extends EventEmitter {
 	 */
 	private async createWebSocketConnection(): Promise<void> {
 		try {
-			assertValidWebSocketUrl(this.finalUrl, this.url);
+			// `verifiedUrl` is the parsed, validated URL returned by the
+			// assertion above; using its `.href` (rather than the original
+			// `this.finalUrl` string) as the connection target ensures the
+			// value handed to the WebSocket constructor has been directly
+			// derived from a validated `URL` instance.
+			const verifiedUrl = assertValidWebSocketUrl(this.finalUrl, this.url);
 
 			let WebSocketConstructor: new (url: string) => WebSocketLike;
 
@@ -143,7 +148,7 @@ export class DataStreamsWebSocket extends EventEmitter {
 				throw new Error('WebSocket not available in this environment');
 			}
 
-			this.conn = new WebSocketConstructor(this.finalUrl);
+			this.conn = new WebSocketConstructor(verifiedUrl.href);
 			this.setupEventHandlers();
 		} catch (error) {
 			const errorMessage =

--- a/packages/datastreams/src/web-socket.ts
+++ b/packages/datastreams/src/web-socket.ts
@@ -245,8 +245,39 @@ export class DataStreamsWebSocket extends EventEmitter {
 	 * Handle WebSocket error event
 	 */
 	private handleWebSocketErrorEvent(event: unknown): void {
-		this.log(`WebSocket error: ${JSON.stringify(event)}`);
+		try {
+			this.log(`WebSocket error: ${this.safeStringify(event)}`);
+		} catch (loggingError) {
+			// Logging must never crash the process (e.g. TLS errors carry
+			// circular references such as issuerCertificate)
+			this.log(
+				`WebSocket error (failed to stringify event: ${
+					loggingError instanceof Error ? loggingError.message : String(loggingError)
+				})`
+			);
+		}
 		this.emit('error', event);
+	}
+
+	/**
+	 * JSON.stringify wrapper that tolerates circular references (e.g. TLS
+	 * error events whose `issuerCertificate` chain references itself) instead
+	 * of throwing and taking down the process.
+	 */
+	private safeStringify(value: unknown): string {
+		const seen = new WeakSet<object>();
+		return JSON.stringify(value, (_key, val) => {
+			if (val instanceof Error) {
+				return { name: val.name, message: val.message, stack: val.stack };
+			}
+			if (typeof val === 'object' && val !== null) {
+				if (seen.has(val)) {
+					return '[Circular]';
+				}
+				seen.add(val);
+			}
+			return val;
+		});
 	}
 
 	/**

--- a/packages/datastreams/tests/datastreams.test.ts
+++ b/packages/datastreams/tests/datastreams.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Test file for DataStreams package
+ */
+import { DataStreams } from '../src/index';
+import { CatalystDataStreamError } from '../src/utils/errors';
+
+// Mock the Handler class from transport
+jest.mock('@zcatalyst/transport', () => ({
+	Handler: jest.fn().mockImplementation(() => ({
+		send: jest.fn()
+	})),
+	RequestType: { JSON: 'json' },
+	ResponseType: { JSON: 'json' }
+}));
+
+// Mock utils
+jest.mock('@zcatalyst/utils', () => ({
+	CONSTANTS: {
+		COMPONENT: { data_streams: 'Datastreams' },
+		REQ_METHOD: { get: 'GET', post: 'POST' },
+		CREDENTIAL_USER: { admin: 'admin', user: 'user' },
+		X_ZOHO_CATALYST_RESOURCE_ID: 'X-Zc-Resource-Id'
+	},
+	CatalystService: { BAAS: 'baas' },
+	Component: {},
+	isNonEmptyObject: jest.fn(),
+	isNonEmptyString: jest.fn(),
+	isValidInputString: jest.fn(),
+	wrapValidatorsWithPromise: jest.fn(),
+	PrefixedCatalystError: class MockPrefixedCatalystError extends Error {
+		constructor(prefix: string, code: string, message: string, value?: unknown) {
+			super(`${prefix}:${code}:${message}`);
+			this.name = 'PrefixedCatalystError';
+		}
+	}
+}));
+
+describe('DataStreams', () => {
+	let dataStreams: DataStreams;
+	let mockSend: jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		dataStreams = new DataStreams();
+		// Get the mocked send function
+		mockSend = (dataStreams as unknown as { requester: { send: jest.Mock } }).requester.send;
+	});
+
+	describe('constructor', () => {
+		it('should create a DataStreams instance', () => {
+			expect(dataStreams).toBeInstanceOf(DataStreams);
+		});
+
+		it('should return the correct component name', () => {
+			expect(dataStreams.getComponentName()).toBe('Datastreams');
+		});
+	});
+
+	describe('getAllChannels', () => {
+		it('should make correct request and return channels data', async () => {
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: [
+						{
+							channel_id: '123',
+							channel_name: 'test-channel',
+							channel_description: 'Test channel',
+							created_time: '2023-01-01T00:00:00.000Z',
+							created_by: 'admin',
+							modified_time: '2023-01-01T00:00:00.000Z',
+							modified_by: 'admin'
+						}
+					]
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			const result = await dataStreams.getAllChannels();
+
+			expect(mockSend).toHaveBeenCalledWith({
+				method: 'GET',
+				path: '/datastreams/channel',
+				user: 'admin',
+				service: 'baas',
+				type: 'json',
+				expecting: 'json'
+			});
+
+			expect(result).toEqual(mockResponse.data.data);
+		});
+
+		it('should propagate the underlying request error on failure', async () => {
+			mockSend.mockRejectedValue(new Error('Network error'));
+
+			await expect(dataStreams.getAllChannels()).rejects.toThrow('Network error');
+		});
+	});
+
+	describe('getChannelDetails', () => {
+		beforeEach(() => {
+			// Mock wrapValidatorsWithPromise to execute the validation
+			const { wrapValidatorsWithPromise } = require('@zcatalyst/utils');
+			wrapValidatorsWithPromise.mockImplementation(async (validationFn: () => void) => {
+				validationFn();
+			});
+		});
+
+		it('should get channel details by ID', async () => {
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: {
+						channel_id: '123',
+						channel_name: 'test-channel',
+						channel_description: 'Test channel',
+						created_time: '2023-01-01T00:00:00.000Z',
+						created_by: 'admin',
+						modified_time: '2023-01-01T00:00:00.000Z',
+						modified_by: 'admin'
+					}
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			const result = await dataStreams.getChannelDetails('123');
+
+			expect(mockSend).toHaveBeenCalledWith({
+				method: 'GET',
+				path: '/datastreams/channel/123',
+				user: 'admin',
+				service: 'baas',
+				type: 'json',
+				expecting: 'json'
+			});
+
+			expect(result).toEqual(mockResponse.data.data);
+		});
+
+		it('should throw CatalystDataStreamError when channelId validation fails', async () => {
+			const { wrapValidatorsWithPromise } = require('@zcatalyst/utils');
+			wrapValidatorsWithPromise.mockRejectedValueOnce(
+				new CatalystDataStreamError('INVALID_ARGUMENT', 'channelId is invalid')
+			);
+
+			await expect(dataStreams.getChannelDetails('')).rejects.toThrow(
+				CatalystDataStreamError
+			);
+			expect(mockSend).not.toHaveBeenCalled();
+		});
+
+		it('should propagate the underlying request error on failure', async () => {
+			mockSend.mockRejectedValue(new Error('Network error'));
+
+			await expect(dataStreams.getChannelDetails('123')).rejects.toThrow('Network error');
+		});
+	});
+
+	describe('getLiveCount', () => {
+		beforeEach(() => {
+			const { wrapValidatorsWithPromise } = require('@zcatalyst/utils');
+			wrapValidatorsWithPromise.mockImplementation(async (validationFn: () => void) => {
+				validationFn();
+			});
+		});
+
+		it('should get live count for a channel', async () => {
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: {
+						live_count: 5
+					}
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			const result = await dataStreams.getLiveCount('123');
+
+			expect(mockSend).toHaveBeenCalledWith({
+				method: 'GET',
+				path: '/datastreams/channel/123/liveclient',
+				user: 'admin',
+				service: 'baas',
+				type: 'json',
+				expecting: 'json'
+			});
+
+			expect(result).toEqual(mockResponse.data);
+		});
+
+		it('should propagate the underlying request error on failure', async () => {
+			mockSend.mockRejectedValue(new Error('Network error'));
+
+			await expect(dataStreams.getLiveCount('123')).rejects.toThrow('Network error');
+		});
+	});
+
+	describe('publishData', () => {
+		beforeEach(() => {
+			const { wrapValidatorsWithPromise } = require('@zcatalyst/utils');
+			wrapValidatorsWithPromise.mockImplementation(async (validationFn: () => void) => {
+				validationFn();
+			});
+		});
+
+		it('should publish data to a channel', async () => {
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: true
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			const result = await dataStreams.publishData('123', 'Hello, World!');
+
+			expect(mockSend).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/datastreams/channel/123/stream',
+				data: { data: 'Hello, World!' },
+				user: 'admin',
+				service: 'baas',
+				type: 'json',
+				expecting: 'json'
+			});
+
+			expect(result).toEqual(mockResponse.data.data);
+		});
+
+		it('should reject when data is empty', async () => {
+			const { isNonEmptyString } = require('@zcatalyst/utils');
+			isNonEmptyString.mockImplementationOnce(
+				(value: unknown, name: string, throwErr: boolean) => {
+					if (throwErr && !value) {
+						throw new CatalystDataStreamError('INVALID_ARGUMENT', `${name} required`);
+					}
+					return Boolean(value);
+				}
+			);
+
+			await expect(dataStreams.publishData('123', '')).rejects.toThrow(
+				CatalystDataStreamError
+			);
+			expect(mockSend).not.toHaveBeenCalled();
+		});
+
+		it('should propagate the underlying request error on failure', async () => {
+			mockSend.mockRejectedValue(new Error('Network error'));
+
+			await expect(dataStreams.publishData('123', 'Hello, World!')).rejects.toThrow(
+				'Network error'
+			);
+		});
+	});
+
+	describe('getTokenPair', () => {
+		beforeEach(() => {
+			const {
+				wrapValidatorsWithPromise,
+				isValidInputString,
+				isNonEmptyString
+			} = require('@zcatalyst/utils');
+			wrapValidatorsWithPromise.mockImplementation(async (validationFn: () => void) => {
+				validationFn();
+			});
+
+			// Mock isValidInputString to return appropriate values
+			isValidInputString.mockImplementation(
+				(value: unknown, name: string, required: boolean) => {
+					if (required && (!value || value === '')) return false;
+					if (!required && value === undefined) return false;
+					return typeof value === 'string' && value.length > 0;
+				}
+			);
+
+			// Mock isNonEmptyString to return true for any non-empty string
+			isNonEmptyString.mockImplementation((value: unknown) => {
+				return typeof value === 'string' && value.length > 0;
+			});
+		});
+
+		it('should get token pair with user ID', async () => {
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: {
+						wss_id: 'session123',
+						channel_id: '123',
+						key: 'token-key',
+						url: 'ws.example.com'
+					}
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			const result = await dataStreams.getTokenPair('123', { userId: '456' });
+
+			expect(mockSend).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/datastreams/channel/123/tokenpair',
+				user: 'user',
+				data: { app_user_id: '456' },
+				service: 'baas',
+				type: 'json',
+				expecting: 'json',
+				headers: {}
+			});
+
+			expect(result).toEqual(mockResponse.data.data);
+		});
+
+		it('should get token pair with connection name', async () => {
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: {
+						wss_id: 'session123',
+						channel_id: '123',
+						key: 'token-key',
+						url: 'ws.example.com'
+					}
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			const result = await dataStreams.getTokenPair('123', {
+				connectionName: 'test-connection'
+			});
+
+			expect(mockSend).toHaveBeenCalledWith({
+				method: 'POST',
+				path: '/datastreams/channel/123/tokenpair',
+				user: 'user',
+				data: { connection_name: 'test-connection' },
+				service: 'baas',
+				type: 'json',
+				expecting: 'json',
+				headers: {}
+			});
+
+			expect(result).toEqual(mockResponse.data.data);
+		});
+
+		it('should throw CatalystDataStreamError when neither userId nor connectionName is provided', async () => {
+			await expect(dataStreams.getTokenPair('123', {})).rejects.toThrow(
+				CatalystDataStreamError
+			);
+			expect(mockSend).not.toHaveBeenCalled();
+		});
+
+		it('should throw CatalystDataStreamError when channelId validation fails', async () => {
+			const { wrapValidatorsWithPromise } = require('@zcatalyst/utils');
+			wrapValidatorsWithPromise.mockRejectedValueOnce(
+				new CatalystDataStreamError('INVALID_ARGUMENT', 'channelId is invalid')
+			);
+
+			await expect(dataStreams.getTokenPair('', { userId: '456' })).rejects.toThrow(
+				CatalystDataStreamError
+			);
+			expect(mockSend).not.toHaveBeenCalled();
+		});
+
+		it('should propagate the underlying request error on failure', async () => {
+			mockSend.mockRejectedValue(new Error('Network error'));
+
+			await expect(dataStreams.getTokenPair('123', { userId: '456' })).rejects.toThrow(
+				'Network error'
+			);
+		});
+
+		it('should include resource id header when running in a non-browser environment', async () => {
+			const originalResourceId = process.env.X_ZOHO_CATALYST_RESOURCE_ID;
+			process.env.X_ZOHO_CATALYST_RESOURCE_ID = 'resource-123';
+
+			const { isNonEmptyString } = require('@zcatalyst/utils');
+			isNonEmptyString.mockReturnValueOnce(true);
+
+			const mockResponse = {
+				data: {
+					status: 'success',
+					data: {
+						wss_id: 'session123',
+						channel_id: '123',
+						key: 'token-key',
+						url: 'ws.example.com'
+					}
+				}
+			};
+
+			mockSend.mockResolvedValue(mockResponse);
+
+			await dataStreams.getTokenPair('123', { userId: '456' });
+
+			expect(mockSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					headers: { 'X-Zc-Resource-Id': 'resource-123' }
+				})
+			);
+
+			process.env.X_ZOHO_CATALYST_RESOURCE_ID = originalResourceId;
+		});
+	});
+});

--- a/packages/datastreams/tests/datastreams.test.ts
+++ b/packages/datastreams/tests/datastreams.test.ts
@@ -289,8 +289,8 @@ describe('DataStreams', () => {
 				data: {
 					status: 'success',
 					data: {
-						wss_id: 'session123',
-						channel_id: '123',
+						'wss-id': 'session123',
+						'channel-id': '123',
 						key: 'token-key',
 						url: 'ws.example.com'
 					}
@@ -320,8 +320,8 @@ describe('DataStreams', () => {
 				data: {
 					status: 'success',
 					data: {
-						wss_id: 'session123',
-						channel_id: '123',
+						'wss-id': 'session123',
+						'channel-id': '123',
 						key: 'token-key',
 						url: 'ws.example.com'
 					}
@@ -386,8 +386,8 @@ describe('DataStreams', () => {
 				data: {
 					status: 'success',
 					data: {
-						wss_id: 'session123',
-						channel_id: '123',
+						'wss-id': 'session123',
+						'channel-id': '123',
 						key: 'token-key',
 						url: 'ws.example.com'
 					}

--- a/packages/datastreams/tests/event-emitter.test.ts
+++ b/packages/datastreams/tests/event-emitter.test.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from '../src/utils/event-emitter';
+
+describe('EventEmitter', () => {
+	let emitter: EventEmitter;
+
+	beforeEach(() => {
+		emitter = new EventEmitter();
+	});
+
+	it('should register and invoke a listener with emit', () => {
+		const listener = jest.fn();
+		emitter.on('greet', listener);
+
+		const emitted = emitter.emit('greet', 'hello', 42);
+
+		expect(listener).toHaveBeenCalledWith('hello', 42);
+		expect(emitted).toBe(true);
+	});
+
+	it('should return false when emitting an event with no listeners', () => {
+		expect(emitter.emit('missing')).toBe(false);
+	});
+
+	it('should support multiple listeners for the same event', () => {
+		const first = jest.fn();
+		const second = jest.fn();
+		emitter.on('multi', first);
+		emitter.on('multi', second);
+
+		emitter.emit('multi');
+
+		expect(first).toHaveBeenCalled();
+		expect(second).toHaveBeenCalled();
+	});
+
+	it('should invoke a once listener exactly one time', () => {
+		const listener = jest.fn();
+		emitter.once('single', listener);
+
+		emitter.emit('single');
+		emitter.emit('single');
+
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('should remove a specific listener with off', () => {
+		const listener = jest.fn();
+		emitter.on('removable', listener);
+		emitter.off('removable', listener);
+
+		emitter.emit('removable');
+
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it('should be a no-op removing a listener that was never registered', () => {
+		const listener = jest.fn();
+		expect(() => emitter.off('unknown', listener)).not.toThrow();
+	});
+
+	it('should remove all listeners for a specific event', () => {
+		const listener = jest.fn();
+		emitter.on('a', listener);
+		emitter.on('b', listener);
+
+		emitter.removeAllListeners('a');
+		emitter.emit('a');
+		emitter.emit('b');
+
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('should remove all listeners for all events when no event is given', () => {
+		const listener = jest.fn();
+		emitter.on('a', listener);
+		emitter.on('b', listener);
+
+		emitter.removeAllListeners();
+		emitter.emit('a');
+		emitter.emit('b');
+
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it('should report listener count for an event', () => {
+		expect(emitter.listenerCount('count')).toBe(0);
+
+		emitter.on('count', jest.fn());
+		emitter.on('count', jest.fn());
+
+		expect(emitter.listenerCount('count')).toBe(2);
+	});
+
+	it('should return the list of listeners for an event', () => {
+		const listener = jest.fn();
+		emitter.on('listed', listener);
+
+		expect(emitter.listeners('listed')).toEqual([listener]);
+		expect(emitter.listeners('unregistered')).toEqual([]);
+	});
+
+	it('should emit an "error" event when a listener throws', () => {
+		const errorListener = jest.fn();
+		emitter.on('error', errorListener);
+		emitter.on('boom', () => {
+			throw new Error('listener failure');
+		});
+
+		emitter.emit('boom');
+
+		expect(errorListener).toHaveBeenCalledWith(new Error('listener failure'));
+	});
+
+	it('should log to console.error when an "error" listener itself throws', () => {
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+		emitter.on('error', () => {
+			throw new Error('error handler failure');
+		});
+
+		emitter.emit('error');
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'EventEmitter error:',
+			new Error('error handler failure')
+		);
+
+		consoleErrorSpy.mockRestore();
+	});
+
+	it('should support method chaining for on/off/once/removeAllListeners', () => {
+		const listener = jest.fn();
+		expect(
+			emitter.on('chain', listener).off('chain', listener).once('chain', listener)
+		).toBeInstanceOf(EventEmitter);
+	});
+});

--- a/packages/datastreams/tests/validators.test.ts
+++ b/packages/datastreams/tests/validators.test.ts
@@ -1,0 +1,71 @@
+import { CatalystDataStreamError } from '../src/utils/errors';
+import { assertValidHost, assertValidWebSocketUrl } from '../src/utils/validators';
+
+describe('assertValidHost', () => {
+	it('should accept a plain hostname', () => {
+		expect(() => assertValidHost('example.com', 'url')).not.toThrow();
+	});
+
+	it('should accept a hostname with hyphenated labels', () => {
+		expect(() => assertValidHost('my-catalyst-domain.example.com', 'url')).not.toThrow();
+	});
+
+	it('should reject a non-string value', () => {
+		expect(() => assertValidHost(undefined, 'url')).toThrow(CatalystDataStreamError);
+		expect(() => assertValidHost(123, 'url')).toThrow(CatalystDataStreamError);
+	});
+
+	it('should reject an empty string', () => {
+		expect(() => assertValidHost('', 'url')).toThrow(CatalystDataStreamError);
+	});
+
+	it.each([
+		['a path segment', 'example.com/evil'],
+		['embedded credentials', 'example.com@attacker.example'],
+		['a port delimiter', 'example.com:1234'],
+		['a fragment', 'example.com#frag'],
+		['a query string', 'example.com?x=1'],
+		['whitespace', 'example.com '],
+		['a backslash', 'example.com\\evil']
+	])('should reject a host containing %s', (_desc, host) => {
+		expect(() => assertValidHost(host, 'url')).toThrow(CatalystDataStreamError);
+	});
+});
+
+describe('assertValidWebSocketUrl', () => {
+	it('should accept a wss url that matches the expected host', () => {
+		expect(() =>
+			assertValidWebSocketUrl('wss://example.com/wsconnect?prd=CY', 'example.com')
+		).not.toThrow();
+	});
+
+	it('should be case-insensitive when comparing hosts', () => {
+		expect(() =>
+			assertValidWebSocketUrl('wss://Example.COM/wsconnect', 'example.com')
+		).not.toThrow();
+	});
+
+	it('should reject a non-wss protocol', () => {
+		expect(() =>
+			assertValidWebSocketUrl('https://example.com/wsconnect', 'example.com')
+		).toThrow(CatalystDataStreamError);
+	});
+
+	it('should reject a url with embedded credentials', () => {
+		expect(() =>
+			assertValidWebSocketUrl('wss://user:pass@example.com/wsconnect', 'example.com')
+		).toThrow(CatalystDataStreamError);
+	});
+
+	it('should reject a url whose host does not match the expected host', () => {
+		expect(() =>
+			assertValidWebSocketUrl('wss://attacker.example/wsconnect', 'example.com')
+		).toThrow(CatalystDataStreamError);
+	});
+
+	it('should reject an unparsable url', () => {
+		expect(() => assertValidWebSocketUrl('not a url', 'example.com')).toThrow(
+			CatalystDataStreamError
+		);
+	});
+});

--- a/packages/datastreams/tests/validators.test.ts
+++ b/packages/datastreams/tests/validators.test.ts
@@ -2,12 +2,12 @@ import { CatalystDataStreamError } from '../src/utils/errors';
 import { assertValidHost, assertValidWebSocketUrl } from '../src/utils/validators';
 
 describe('assertValidHost', () => {
-	it('should accept a plain hostname', () => {
-		expect(() => assertValidHost('example.com', 'url')).not.toThrow();
+	it('should accept an allow-listed DataStreams hostname', () => {
+		expect(() => assertValidHost('us4-dms.zoho.com', 'url')).not.toThrow();
 	});
 
-	it('should accept a hostname with hyphenated labels', () => {
-		expect(() => assertValidHost('my-catalyst-domain.example.com', 'url')).not.toThrow();
+	it('should accept an allow-listed DataStreams hostname regardless of case', () => {
+		expect(() => assertValidHost('US4-DMS.ZOHO.COM', 'url')).not.toThrow();
 	});
 
 	it('should reject a non-string value', () => {
@@ -19,14 +19,20 @@ describe('assertValidHost', () => {
 		expect(() => assertValidHost('', 'url')).toThrow(CatalystDataStreamError);
 	});
 
+	it('should reject an arbitrary hostname not on the allow-list', () => {
+		expect(() => assertValidHost('example.com', 'url')).toThrow(CatalystDataStreamError);
+	});
+
 	it.each([
-		['a path segment', 'example.com/evil'],
-		['embedded credentials', 'example.com@attacker.example'],
-		['a port delimiter', 'example.com:1234'],
-		['a fragment', 'example.com#frag'],
-		['a query string', 'example.com?x=1'],
-		['whitespace', 'example.com '],
-		['a backslash', 'example.com\\evil']
+		['a path segment', 'us4-dms.zoho.com/evil'],
+		['embedded credentials', 'us4-dms.zoho.com@attacker.example'],
+		['a port delimiter', 'us4-dms.zoho.com:1234'],
+		['a fragment', 'us4-dms.zoho.com#frag'],
+		['a query string', 'us4-dms.zoho.com?x=1'],
+		['whitespace', 'us4-dms.zoho.com '],
+		['a backslash', 'us4-dms.zoho.com\\evil'],
+		['a private/internal-style host', '169.254.169.254'],
+		['a localhost-style host', 'localhost']
 	])('should reject a host containing %s', (_desc, host) => {
 		expect(() => assertValidHost(host, 'url')).toThrow(CatalystDataStreamError);
 	});

--- a/packages/datastreams/tests/web-socket.test.ts
+++ b/packages/datastreams/tests/web-socket.test.ts
@@ -1,0 +1,584 @@
+import { DataStreamsWebSocket } from '../src/web-socket';
+
+/**
+ * Minimal mock of a WebSocket implementation exposing the Node.js `ws`
+ * style API (`on`/`send`/`close`) that `DataStreamsWebSocket` relies on.
+ */
+class MockWebSocket {
+	readyState = 1; // OPEN
+	OPEN = 1;
+	CLOSED = 3;
+	CONNECTING = 0;
+	CLOSING = 2;
+
+	send = jest.fn();
+	close = jest.fn();
+
+	private listeners: Record<string, Array<(...args: Array<unknown>) => void>> = {};
+
+	on = jest.fn((event: string, callback: (...args: Array<unknown>) => void) => {
+		(this.listeners[event] ??= []).push(callback);
+	});
+
+	trigger(event: string, ...args: Array<unknown>) {
+		(this.listeners[event] ?? []).forEach((cb) => cb(...args));
+	}
+}
+
+let mockWebSocket: MockWebSocket;
+const webSocketCtor = jest.fn(() => mockWebSocket);
+
+// Simulate a browser-like global so `DataStreamsWebSocket` picks up our mock constructor.
+(global as unknown as { window: { WebSocket: typeof webSocketCtor } }).window = {
+	WebSocket: webSocketCtor
+};
+
+const baseConfig = { url: 'example.com', zuid: 'user123', key: 'key123' };
+
+function connectMessage(sid = 'sid-1', uid = 'uid-1') {
+	return JSON.stringify([{ mtype: '0', msg: { sid, uid } }]);
+}
+
+function dataEventMessage(opr: string, extra: Record<string, unknown> = {}, streamingId = 's-1') {
+	return JSON.stringify([{ mtype: '650', msg: { opr, data: { streamingId, ...extra } } }]);
+}
+
+describe('DataStreamsWebSocket', () => {
+	let websocket: DataStreamsWebSocket;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockWebSocket = new MockWebSocket();
+	});
+
+	afterEach(() => {
+		websocket?.close();
+	});
+
+	describe('constructor', () => {
+		it('should build the correct WebSocket URL and create a connection', () => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+
+			expect(webSocketCtor).toHaveBeenCalledWith(
+				'wss://example.com/wsconnect?prd=CY&zuid=user123&key=key123'
+			);
+		});
+
+		it('should default enableLogging to false', () => {
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('open');
+
+			expect(consoleSpy).not.toHaveBeenCalled();
+			consoleSpy.mockRestore();
+		});
+
+		it('should log when enableLogging is true', () => {
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			websocket = new DataStreamsWebSocket({ ...baseConfig, enableLogging: true });
+			mockWebSocket.trigger('open');
+
+			expect(consoleSpy).toHaveBeenCalled();
+			consoleSpy.mockRestore();
+		});
+
+		it('should throw when url is missing', () => {
+			expect(() => new DataStreamsWebSocket({ ...baseConfig, url: '' })).toThrow();
+		});
+
+		it('should throw when key is missing', () => {
+			expect(() => new DataStreamsWebSocket({ ...baseConfig, key: '' })).toThrow();
+		});
+
+		it('should throw when zuid is missing', () => {
+			expect(() => new DataStreamsWebSocket({ ...baseConfig, zuid: '' })).toThrow();
+		});
+
+		it.each([
+			['a path segment', 'example.com/evil'],
+			['embedded credentials', 'example.com@attacker.example'],
+			['a port delimiter', 'example.com:1234']
+		])('should reject a url containing %s (SSRF guard)', (_desc, url) => {
+			expect(() => new DataStreamsWebSocket({ ...baseConfig, url })).toThrow();
+			expect(webSocketCtor).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('connection lifecycle', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+		});
+
+		it('should be connected once the socket opens', () => {
+			mockWebSocket.trigger('open');
+
+			expect(websocket.isConnected()).toBe(true);
+			expect(websocket.getConnectionState()).toBe('connected');
+		});
+
+		it('should emit close and stop reporting as connected on close', () => {
+			const closeListener = jest.fn();
+			websocket.on('close', closeListener);
+
+			mockWebSocket.trigger('open');
+			mockWebSocket.readyState = mockWebSocket.CLOSED;
+			mockWebSocket.trigger('close', { code: 1000, reason: 'bye' });
+
+			expect(closeListener).toHaveBeenCalledWith({ code: 1000, reason: 'bye' });
+			expect(websocket.isConnected()).toBe(false);
+		});
+
+		it('should emit an error event on socket error', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('error', new Error('boom'));
+
+			expect(errorListener).toHaveBeenCalledWith(new Error('boom'));
+		});
+
+		it('should emit a pong event for empty messages', () => {
+			const pongListener = jest.fn();
+			websocket.on('pong', pongListener);
+
+			mockWebSocket.trigger('message', '');
+
+			expect(pongListener).toHaveBeenCalledWith({ message: 'Pong received' });
+		});
+
+		it('should not throw and should log on invalid JSON messages', () => {
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			expect(() => mockWebSocket.trigger('message', 'not-json{')).not.toThrow();
+
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('server message handling', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+		});
+
+		it('should store session info and emit open on auth success (mtype 0)', () => {
+			const openListener = jest.fn();
+			websocket.on('open', openListener);
+
+			mockWebSocket.trigger('message', connectMessage('sid-99', 'uid-99'));
+
+			expect(openListener).toHaveBeenCalledWith(expect.objectContaining({ code: 200 }));
+			expect(websocket.getSessionInfo()).toEqual({ sid: 'sid-99', uid: 'uid-99' });
+		});
+
+		it('should emit an error for missing key (mtype -2)', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', JSON.stringify([{ mtype: '-2' }]));
+
+			expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ code: 1014 }));
+		});
+
+		it('should emit an error for authentication failure (mtype -5)', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', JSON.stringify([{ mtype: '-5' }]));
+
+			expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ code: 3000 }));
+		});
+
+		it('should emit an error when a session expires without key-mismatch', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', JSON.stringify([{ mtype: '-11', reason: 'other' }]));
+
+			expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ code: 1000 }));
+		});
+
+		it('should retry the connection once on key-mismatch session expiry', () => {
+			mockWebSocket.trigger(
+				'message',
+				JSON.stringify([{ mtype: '-11', reason: 'key_mismatch' }])
+			);
+
+			// A second WebSocket connection is created as part of the retry.
+			expect(webSocketCtor).toHaveBeenCalledTimes(2);
+		});
+
+		it('should emit an error when the connection is blocked (mtype 660)', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', JSON.stringify([{ mtype: '660' }]));
+
+			expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ code: 1013 }));
+		});
+
+		it('should emit an error when the server is down (mtype 670)', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', JSON.stringify([{ mtype: '670' }]));
+
+			expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ code: 1011 }));
+		});
+
+		it('should switch URL and reconnect (mtype -1)', () => {
+			mockWebSocket.trigger('message', connectMessage('sid-1', 'uid-1'));
+			webSocketCtor.mockClear();
+
+			mockWebSocket.trigger(
+				'message',
+				JSON.stringify([{ mtype: '-1', msg: { primarydc: 'dc1', dc1: 'new-host.com' } }])
+			);
+
+			expect(mockWebSocket.close).toHaveBeenCalled();
+			expect(webSocketCtor).toHaveBeenCalledTimes(1);
+		});
+
+		it('should reject a malicious switch-url host and not reconnect (SSRF guard)', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', connectMessage('sid-1', 'uid-1'));
+			webSocketCtor.mockClear();
+			mockWebSocket.close.mockClear();
+
+			mockWebSocket.trigger(
+				'message',
+				JSON.stringify([
+					{ mtype: '-1', msg: { primarydc: 'dc1', dc1: 'attacker.example/evil' } }
+				])
+			);
+
+			expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ code: 1007 }));
+			expect(mockWebSocket.close).not.toHaveBeenCalled();
+			expect(webSocketCtor).not.toHaveBeenCalled();
+		});
+
+		it('should emit a data message for an "event" operation (mtype 650)', () => {
+			const messageListener = jest.fn();
+			websocket.on('message', messageListener);
+
+			mockWebSocket.trigger('message', dataEventMessage('event', { data: 'payload' }));
+
+			expect(messageListener).toHaveBeenCalledWith({
+				data: 'payload',
+				streamingId: 's-1'
+			});
+		});
+
+		it('should emit a data message for an "api" operation (mtype 650)', () => {
+			const messageListener = jest.fn();
+			websocket.on('message', messageListener);
+
+			mockWebSocket.trigger(
+				'message',
+				dataEventMessage('api', { url: '/foo', method: 'GET' })
+			);
+
+			expect(messageListener).toHaveBeenCalledWith({
+				streamingId: 's-1',
+				url: '/foo',
+				method: 'GET'
+			});
+		});
+
+		it('should emit an error for an "error" operation (mtype 650)', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', dataEventMessage('error', { value: 'oops' }));
+
+			expect(errorListener).toHaveBeenCalledWith({ error: 'oops' });
+		});
+
+		it('should use a specific message for subscription errors e3/e5', () => {
+			const errorListener = jest.fn();
+			websocket.on('error', errorListener);
+
+			mockWebSocket.trigger('message', dataEventMessage('error', { code: 'e3' }));
+
+			expect(errorListener).toHaveBeenCalledWith({
+				error: 'Subscription failed. Invalid subscription type.'
+			});
+		});
+	});
+
+	describe('subscribe / unsubscribe', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('open');
+		});
+
+		it('should subscribe with the given type', () => {
+			websocket.subscribe('1');
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'con', value: 'subscribe', streamingId: '1' })
+			);
+		});
+
+		it('should default to subscribing with type "0"', () => {
+			websocket.subscribe();
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'con', value: 'subscribe', streamingId: '0' })
+			);
+		});
+
+		it('should throw when subscribing on a closed connection', () => {
+			mockWebSocket.readyState = mockWebSocket.CLOSED;
+
+			expect(() => websocket.subscribe('0')).toThrow('WebSocket connection is not open');
+		});
+
+		it('should unsubscribe', () => {
+			websocket.unsubscribe();
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'con', value: 'unsubscribe' })
+			);
+		});
+
+		it('should throw when unsubscribing on a closed connection', () => {
+			mockWebSocket.readyState = mockWebSocket.CLOSED;
+
+			expect(() => websocket.unsubscribe()).toThrow('WebSocket connection is not open');
+		});
+	});
+
+	describe('sendAck', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('open');
+		});
+
+		it('should send an acknowledgment once a streaming id is known', () => {
+			mockWebSocket.trigger('message', dataEventMessage('event', { data: 'x' }));
+			mockWebSocket.send.mockClear();
+
+			websocket.sendAck();
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'ack', streamingId: 's-1' })
+			);
+		});
+
+		it('should not send when there is no streaming id yet', () => {
+			websocket.sendAck();
+
+			expect(mockWebSocket.send).not.toHaveBeenCalled();
+		});
+
+		it('should not send when the connection is closed', () => {
+			mockWebSocket.trigger('message', dataEventMessage('event', { data: 'x' }));
+			mockWebSocket.send.mockClear();
+			mockWebSocket.readyState = mockWebSocket.CLOSED;
+
+			websocket.sendAck();
+
+			expect(mockWebSocket.send).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('data event edge cases', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+		});
+
+		it('should send an ack for a repeated streaming id once acknowledged', () => {
+			mockWebSocket.trigger('message', dataEventMessage('event', { data: 'x' }));
+			websocket.sendAck();
+			mockWebSocket.send.mockClear();
+
+			// Same streamingId ('s-1') arrives again after being acknowledged.
+			mockWebSocket.trigger('message', dataEventMessage('event', { data: 'x' }));
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'ack', streamingId: 's-1' })
+			);
+		});
+
+		it('should send a pong-style ack for the "connect" operation once acknowledged', () => {
+			mockWebSocket.trigger('message', dataEventMessage('event', { data: 'x' }, 's-1'));
+			websocket.sendAck();
+			mockWebSocket.send.mockClear();
+
+			mockWebSocket.trigger('message', dataEventMessage('connect', {}, 's-2'));
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'ack', streamingId: '-2' })
+			);
+		});
+	});
+
+	describe('browser-style event handlers', () => {
+		it('should attach onopen/onclose/onmessage/onerror handlers when the socket lacks `.on`', () => {
+			const browserSocket: Record<string, unknown> = {
+				readyState: 1,
+				OPEN: 1,
+				CLOSED: 3,
+				CONNECTING: 0,
+				CLOSING: 2,
+				send: jest.fn(),
+				close: jest.fn()
+			};
+			webSocketCtor.mockImplementationOnce(() => browserSocket as unknown as MockWebSocket);
+
+			websocket = new DataStreamsWebSocket(baseConfig);
+
+			expect(typeof browserSocket.onopen).toBe('function');
+			expect(typeof browserSocket.onclose).toBe('function');
+			expect(typeof browserSocket.onmessage).toBe('function');
+			expect(typeof browserSocket.onerror).toBe('function');
+
+			const openListener = jest.fn();
+			websocket.on('open', openListener);
+
+			(browserSocket.onmessage as (event: { data: string }) => void)({
+				data: connectMessage()
+			});
+
+			expect(openListener).toHaveBeenCalled();
+		});
+	});
+
+	describe('reconnection flow', () => {
+		it('should resubscribe and restart timers when reconnecting with an active ack', () => {
+			jest.useFakeTimers();
+			websocket = new DataStreamsWebSocket(baseConfig);
+
+			// Simulate internal state as if a reconnect attempt is in progress.
+			(websocket as unknown as { reconnect: boolean }).reconnect = true;
+			(websocket as unknown as { ackSent: boolean }).ackSent = true;
+
+			mockWebSocket.trigger('open');
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'con', value: 'subscribe', streamingId: '-2' })
+			);
+			expect(websocket.isConnected()).toBe(true);
+
+			jest.useRealTimers();
+		});
+
+		it('should close and reopen the connection after the 27 minute reconnect window', () => {
+			jest.useFakeTimers();
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('message', connectMessage('sid-1', 'uid-1'));
+
+			(websocket as unknown as { reconnect: boolean }).reconnect = true;
+			mockWebSocket.trigger('open');
+
+			webSocketCtor.mockClear();
+			jest.advanceTimersByTime(27 * 60 * 1000);
+
+			expect(mockWebSocket.close).toHaveBeenCalledWith(
+				1000,
+				'Closing this connection and opening new connection!'
+			);
+
+			jest.advanceTimersByTime(50);
+			expect(webSocketCtor).toHaveBeenCalledTimes(1);
+
+			jest.useRealTimers();
+		});
+	});
+
+	describe('ping and reconnect timers', () => {
+		beforeEach(() => {
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		it('should send a keep-alive ping every 15 seconds while open', () => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('message', connectMessage());
+
+			mockWebSocket.send.mockClear();
+			jest.advanceTimersByTime(15000);
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith('-');
+		});
+
+		it('should stop pinging once the connection is no longer open', () => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('message', connectMessage());
+
+			mockWebSocket.readyState = mockWebSocket.CLOSED;
+			mockWebSocket.send.mockClear();
+			jest.advanceTimersByTime(15000);
+
+			expect(mockWebSocket.send).not.toHaveBeenCalledWith('-');
+		});
+
+		it('should ping the server every 60 seconds while open', () => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('message', connectMessage());
+
+			mockWebSocket.send.mockClear();
+			jest.advanceTimersByTime(60000);
+
+			expect(mockWebSocket.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'con', value: 'ping' })
+			);
+		});
+	});
+
+	describe('connection state', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+		});
+
+		it.each([
+			[0, 'connecting'],
+			[1, 'connected'],
+			[2, 'closing'],
+			[3, 'closed']
+		])('should map readyState %d to "%s"', (readyState, expected) => {
+			mockWebSocket.readyState = readyState;
+			expect(websocket.getConnectionState()).toBe(expected);
+		});
+
+		it('should return session info defaults before authentication', () => {
+			expect(websocket.getSessionInfo()).toEqual({ sid: '', uid: '' });
+		});
+	});
+
+	describe('close', () => {
+		beforeEach(() => {
+			websocket = new DataStreamsWebSocket(baseConfig);
+			mockWebSocket.trigger('open');
+		});
+
+		it('should close the underlying connection', () => {
+			websocket.close();
+
+			expect(mockWebSocket.close).toHaveBeenCalledWith(
+				1000,
+				'Closing connection intentionally'
+			);
+		});
+
+		it('should clear active intervals on close', () => {
+			const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+			const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+			mockWebSocket.trigger('message', connectMessage());
+			websocket.close();
+
+			expect(clearIntervalSpy).toHaveBeenCalled();
+
+			clearIntervalSpy.mockRestore();
+			clearTimeoutSpy.mockRestore();
+		});
+	});
+});

--- a/packages/datastreams/tests/web-socket.test.ts
+++ b/packages/datastreams/tests/web-socket.test.ts
@@ -33,7 +33,7 @@ const webSocketCtor = jest.fn(() => mockWebSocket);
 	WebSocket: webSocketCtor
 };
 
-const baseConfig = { url: 'example.com', zuid: 'user123', key: 'key123' };
+const baseConfig = { url: 'us4-dms.zoho.com', zuid: 'user123', key: 'key123' };
 
 function connectMessage(sid = 'sid-1', uid = 'uid-1') {
 	return JSON.stringify([{ mtype: '0', msg: { sid, uid } }]);
@@ -60,7 +60,7 @@ describe('DataStreamsWebSocket', () => {
 			websocket = new DataStreamsWebSocket(baseConfig);
 
 			expect(webSocketCtor).toHaveBeenCalledWith(
-				'wss://example.com/wsconnect?prd=CY&zuid=user123&key=key123'
+				'wss://us4-dms.zoho.com/wsconnect?prd=CY&zuid=user123&key=key123'
 			);
 		});
 
@@ -97,9 +97,10 @@ describe('DataStreamsWebSocket', () => {
 		});
 
 		it.each([
-			['a path segment', 'example.com/evil'],
-			['embedded credentials', 'example.com@attacker.example'],
-			['a port delimiter', 'example.com:1234']
+			['a path segment', 'us4-dms.zoho.com/evil'],
+			['embedded credentials', 'us4-dms.zoho.com@attacker.example'],
+			['a port delimiter', 'us4-dms.zoho.com:1234'],
+			['a host not on the allow-list', 'attacker.example']
 		])('should reject a url containing %s (SSRF guard)', (_desc, url) => {
 			expect(() => new DataStreamsWebSocket({ ...baseConfig, url })).toThrow();
 			expect(webSocketCtor).not.toHaveBeenCalled();
@@ -233,7 +234,9 @@ describe('DataStreamsWebSocket', () => {
 
 			mockWebSocket.trigger(
 				'message',
-				JSON.stringify([{ mtype: '-1', msg: { primarydc: 'dc1', dc1: 'new-host.com' } }])
+				JSON.stringify([
+					{ mtype: '-1', msg: { primarydc: 'dc1', dc1: 'us3-dms.zoho.com' } }
+				])
 			);
 
 			expect(mockWebSocket.close).toHaveBeenCalled();

--- a/packages/datastreams/tsconfig.cjs.json
+++ b/packages/datastreams/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/datastreams/tsconfig.es.json
+++ b/packages/datastreams/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom"],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/datastreams/tsconfig.types.json
+++ b/packages/datastreams/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/packages/datastreams/typedoc.json
+++ b/packages/datastreams/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPoints": ["src/**/*"],
+  "exclude": ["src/__mocks__/**/*"],
+  "out": "../../docs/datastreams"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,43 @@ importers:
         specifier: workspace:^
         version: link:../utils
 
+  packages/datastreams:
+    dependencies:
+      '@zcatalyst/transport':
+        specifier: workspace:*
+        version: link:../transport
+      '@zcatalyst/utils':
+        specifier: workspace:*
+        version: link:../utils
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
+      downlevel-dts:
+        specifier: ^0.11.0
+        version: 0.11.0
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.19.43)
+      jest-environment-jsdom:
+        specifier: ^30.0.5
+        version: 30.4.1
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
   packages/functions:
     dependencies:
       '@zcatalyst/transport':
@@ -318,6 +355,9 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -469,6 +509,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
@@ -553,6 +597,34 @@ packages:
     resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
     engines: {node: '>=v18'}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -632,9 +704,23 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/environment-jsdom-abstract@30.4.1':
+    resolution: {integrity: sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+      jsdom: '*'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   '@jest/environment@29.7.0':
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/environment@30.4.1':
+    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
@@ -647,6 +733,10 @@ packages:
   '@jest/fake-timers@29.7.0':
     resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/fake-timers@30.4.1':
+    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/globals@29.7.0':
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
@@ -754,6 +844,9 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
@@ -831,6 +924,9 @@ packages:
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -839,6 +935,9 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
@@ -854,6 +953,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -951,6 +1053,10 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -1207,6 +1313,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@8.2.2:
+    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+
   concurrently@9.2.3:
     resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
     engines: {node: '>=18'}
@@ -1272,6 +1383,10 @@ packages:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
     engines: {node: '>=8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
@@ -1279,6 +1394,14 @@ packages:
   data-urls@3.0.2:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1687,6 +1810,10 @@ packages:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1697,9 +1824,17 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1901,6 +2036,15 @@ packages:
       canvas:
         optional: true
 
+  jest-environment-jsdom@30.4.1:
+    resolution: {integrity: sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1929,9 +2073,17 @@ packages:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-pnp-resolver@1.2.3:
     resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
@@ -2026,6 +2178,15 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
     peerDependenciesMeta:
       canvas:
         optional: true
@@ -2145,6 +2306,9 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -2441,6 +2605,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -2471,6 +2639,9 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.8:
+    resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
 
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -2544,6 +2715,9 @@ packages:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -2626,6 +2800,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
 
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
@@ -2749,6 +2926,13 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -2760,9 +2944,17 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2921,6 +3113,10 @@ packages:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -2933,13 +3129,26 @@ packages:
     engines: {node: '>=12'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-url@11.0.0:
     resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
     engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2987,6 +3196,10 @@ packages:
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -3036,6 +3249,14 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3201,6 +3422,8 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -3336,6 +3559,26 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -3452,12 +3695,30 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/jsdom': 21.1.7
+      '@types/node': 20.19.43
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jsdom: 26.1.0
+
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.20.0
       jest-mock: 29.7.0
+
+  '@jest/environment@30.4.1':
+    dependencies:
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 20.19.43
+      jest-mock: 30.4.1
 
   '@jest/expect-utils@29.7.0':
     dependencies:
@@ -3479,6 +3740,15 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
+  '@jest/fake-timers@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+      '@sinonjs/fake-timers': 15.4.0
+      '@types/node': 20.19.43
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+
   '@jest/globals@29.7.0':
     dependencies:
       '@jest/environment': 29.7.0
@@ -3490,9 +3760,8 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 20.19.43
       jest-regex-util: 30.4.0
-    optional: true
 
   '@jest/reporters@29.7.0':
     dependencies:
@@ -3530,7 +3799,6 @@ snapshots:
   '@jest/schemas@30.4.1':
     dependencies:
       '@sinclair/typebox': 0.34.49
-    optional: true
 
   '@jest/source-map@29.6.3':
     dependencies:
@@ -3607,10 +3875,9 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.20.0
+      '@types/node': 20.19.43
       '@types/yargs': 17.0.35
       chalk: 4.1.2
-    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3670,14 +3937,17 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
-  '@sinclair/typebox@0.34.49':
-    optional: true
+  '@sinclair/typebox@0.34.49': {}
 
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
 
   '@sinonjs/fake-timers@10.3.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
@@ -3766,6 +4036,12 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 20.19.43
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -3773,6 +4049,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/minimist@1.2.5': {}
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.20.0':
     dependencies:
@@ -3785,6 +4065,10 @@ snapshots:
   '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -3912,6 +4196,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   ajv@6.15.0:
     dependencies:
@@ -4135,8 +4421,7 @@ snapshots:
 
   ci-info@3.9.0: {}
 
-  ci-info@4.4.0:
-    optional: true
+  ci-info@4.4.0: {}
 
   cjs-module-lexer@1.4.3: {}
 
@@ -4190,6 +4475,18 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@8.2.2:
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.18.1
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.3
+
   concurrently@9.2.3:
     dependencies:
       chalk: 4.1.2
@@ -4241,6 +4538,21 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  create-jest@29.7.0(@types/node@20.19.43):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.19.43)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@22.20.0):
     dependencies:
       '@jest/types': 29.6.3
@@ -4272,6 +4584,11 @@ snapshots:
     dependencies:
       cssom: 0.3.8
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   dargs@8.1.0: {}
 
   data-urls@3.0.2:
@@ -4279,6 +4596,15 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
 
   debug@4.4.3:
     dependencies:
@@ -4683,6 +5009,10 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
@@ -4695,9 +5025,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -4860,6 +5204,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@20.19.43):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.19.43)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.19.43)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.20.0):
     dependencies:
       '@jest/core': 29.7.0
@@ -4878,6 +5241,36 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.43):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@22.20.0):
     dependencies:
@@ -4938,6 +5331,16 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jest-environment-jsdom@30.4.1:
+    dependencies:
+      '@jest/environment': 30.4.1
+      '@jest/environment-jsdom-abstract': 30.4.1(jsdom@26.1.0)
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5010,11 +5413,30 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-message-util@30.4.1:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@jest/types': 30.4.1
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-util: 30.4.1
+      picomatch: 4.0.4
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
       '@types/node': 22.20.0
       jest-util: 29.7.0
+
+  jest-mock@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 20.19.43
+      jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
     optionalDependencies:
@@ -5022,8 +5444,7 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-regex-util@30.4.0:
-    optional: true
+  jest-regex-util@30.4.0: {}
 
   jest-resolve-dependencies@29.7.0:
     dependencies:
@@ -5134,12 +5555,11 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 22.20.0
+      '@types/node': 20.19.43
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
       picomatch: 4.0.4
-    optional: true
 
   jest-validate@29.7.0:
     dependencies:
@@ -5187,6 +5607,18 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
     optional: true
+
+  jest@29.7.0(@types/node@20.19.43):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.19.43)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@22.20.0):
     dependencies:
@@ -5236,6 +5668,33 @@ snapshots:
       whatwg-url: 11.0.0
       ws: 8.21.0
       xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5345,6 +5804,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
 
@@ -5630,6 +6091,13 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  pretty-format@30.4.1:
+    dependencies:
+      '@jest/schemas': 30.4.1
+      ansi-styles: 5.2.0
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.8
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -5652,6 +6120,8 @@ snapshots:
   quick-lru@4.0.1: {}
 
   react-is@18.3.1: {}
+
+  react-is@19.2.8: {}
 
   read-pkg-up@7.0.1:
     dependencies:
@@ -5727,6 +6197,8 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  rrweb-cssom@0.8.0: {}
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -5798,6 +6270,8 @@ snapshots:
   source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spawn-command@0.0.2: {}
 
   spdx-correct@3.2.0:
     dependencies:
@@ -5915,6 +6389,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
@@ -5928,7 +6408,15 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@3.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
 
@@ -6076,6 +6564,10 @@ snapshots:
     dependencies:
       xml-name-validator: 4.0.0
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -6086,11 +6578,22 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@11.0.0:
     dependencies:
       tr46: 3.0.0
+      webidl-conversions: 7.0.0
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
       webidl-conversions: 7.0.0
 
   which@2.0.2:
@@ -6129,6 +6632,8 @@ snapshots:
   ws@8.21.0: {}
 
   xml-name-validator@4.0.0: {}
+
+  xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Description

Adds a new `@zcatalyst/datastreams` package implementing the Catalyst Data Streams service — a real-time publish/subscribe messaging system built on WebSockets for bidirectional client-server communication (chat, live dashboards, notifications, collaborative tools, etc.).

### What's included

- **`DataStreams` / `DataStreamsAdmin`** components:
  - `getAllChannels()` – list all Data Stream channels
  - `getChannelDetails(channelId)` – fetch details of a channel by ID or name
  - `publishData(channelId, data)` – publish a message to a channel
  - `getTokenPair(channelId, options)` – retrieve WebSocket auth token pair (by user ID or connection name)
  - Live connection count retrieval
- **`DataStreamsWebSocket`** – a cross-platform (browser + Node.js) WebSocket client (`src/web-socket.ts`) with:
  - Token-based authentication (`key`/`zuid`)
  - Automatic reconnect and primary-datacenter (DC) failover handling via server-driven `SWITCH_URL` messages
  - Subscribe/unsubscribe/ack/ping message handling
  - A lightweight custom `EventEmitter` (`src/utils/event-emitter.ts`) for connection/message/error events
- **Validators** (`src/utils/validators.ts`) restricting WebSocket connections to a fixed allow-list of legitimate Catalyst DataStreams (DMS) hosts, and verifying that constructed URLs resolve to the expected `wss:` origin.
- Full type definitions (`src/utils/interfaces.ts`), enums (`src/utils/enum.ts`), and error types (`CatalystDataStreamError`).
- Unit tests for `datastreams`, `web-socket`, `event-emitter`, and `validators` (102 tests, 100% coverage on `utils/`).
- Package scaffolding (`package.json`, `tsconfig.*`, `jest.config.js`, `typedoc.json`, `README.md`, `CHANGELOG.md`).

## Testing

- `packages/datastreams/tests/*.test.ts` cover channel APIs, WebSocket connection/reconnect/failover flows, event emitter behavior, and host/URL validators — including explicit SSRF-guard cases (path segments, embedded credentials, port delimiters, non-allow-listed hosts, private/metadata-style hosts).
- 102/102 tests passing, 100% statement/branch coverage on `src/utils`.
- Verified via `pnpm --filter @zcatalyst/datastreams test` and `tsc --noEmit`.

## Files Changed

- `packages/datastreams/**` (new package)
- `pnpm-lock.yaml`

### Checklist
- [ ] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [ ] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
