### PR TITLE
feat(datastore): add olap query support

### DIFF
--- a/packages/datastore/src/datastore.ts
+++ b/packages/datastore/src/datastore.ts
@@ -99,6 +99,40 @@ export class Datastore implements Component {
 	}
 
 	/**
+	 * Executes an OLAP (Online Analytical Processing) ZCQL query against the datastore.
+	 *
+	 * @param sql - The ZCQL query string to execute in OLAP mode.
+	 * @returns A promise resolving to an array of table values.
+	 * @throws {@link CatalystDataStoreError} if the query string is empty or invalid.
+	 *
+	 * @example
+	 * const datastore = new Datastore();
+	 * const rows = await datastore.executeOLAPQuery(
+	 *   "SELECT * FROM Users WHERE status = 'active'"
+	 * );
+	 */
+	async executeOLAPQuery(sql: string): Promise<Array<ICatalystZCQLResult>> {
+		await wrapValidatorsWithPromise(() => {
+			isNonEmptyString(sql, 'query', true);
+		}, CatalystDataStoreError);
+		const request: IRequestConfig = {
+			method: REQ_METHOD.post,
+			path: '/query',
+			data: { query: sql, OLAP: true },
+			type: RequestType.JSON,
+			expecting: ResponseType.JSON,
+			service: CatalystService.BAAS,
+			track: true,
+			user: CREDENTIAL_USER.user,
+			headers: {
+				[ACCEPT_HEADER.KEY]: ACCEPT_HEADER.ZCQL
+			}
+		};
+		const resp = await this.requester.send(request);
+		return resp.data.data as Array<ICatalystZCQLResult>;
+	}
+
+	/**
 	 * Executes a search query on the Catalyst search service over Datastore records.
 	 *
 	 * @param searchQuery - Search criteria containing the query and table columns to search within.

--- a/packages/datastore/src/datastore.ts
+++ b/packages/datastore/src/datastore.ts
@@ -101,7 +101,7 @@ export class Datastore implements Component {
 	/**
 	 * Executes an OLAP (Online Analytical Processing) ZCQL query against the datastore.
 	 *
-	 * @param sql - The ZCQL query string to execute in OLAP mode.
+	 * @param query - The ZCQL query string to execute in OLAP mode.
 	 * @returns A promise resolving to an array of table values.
 	 * @throws {@link CatalystDataStoreError} if the query string is empty or invalid.
 	 *
@@ -111,14 +111,14 @@ export class Datastore implements Component {
 	 *   "SELECT * FROM Users WHERE status = 'active'"
 	 * );
 	 */
-	async executeOLAPQuery(sql: string): Promise<Array<ICatalystZCQLResult>> {
+	async executeOLAPQuery(query: string): Promise<Array<ICatalystZCQLResult>> {
 		await wrapValidatorsWithPromise(() => {
-			isNonEmptyString(sql, 'query', true);
+			isNonEmptyString(query, 'query', true);
 		}, CatalystDataStoreError);
 		const request: IRequestConfig = {
 			method: REQ_METHOD.post,
 			path: '/query',
-			data: { query: sql, OLAP: true },
+			data: { query, OLAP: true },
 			type: RequestType.JSON,
 			expecting: ResponseType.JSON,
 			service: CatalystService.BAAS,

--- a/packages/datastore/tests/datastore.test.ts
+++ b/packages/datastore/tests/datastore.test.ts
@@ -89,6 +89,13 @@ describe('test datastore', () => {
 		await expect(datastore.executeZCQLQuery('')).rejects.toThrow();
 	});
 
+	it('execute OLAP query', async () => {
+		await expect(datastore.executeOLAPQuery('SELECT * FROM Users')).resolves.toStrictEqual(
+			responses['/query'].POST.data.data
+		);
+		await expect(datastore.executeOLAPQuery('')).rejects.toThrow();
+	});
+
 	it('execute search query', async () => {
 		await expect(
 			datastore.executeSearchQuery({


### PR DESCRIPTION
### Summary
Adds support for executing OLAP (Online Analytical Processing) ZCQL queries against the Catalyst Datastore.

### Changes
- **`packages/datastore/src/datastore.ts`**: Added a new `executeOLAPQuery(query: string)` method to the `Datastore` class.
  - Validates that the input `query` is a non-empty string, throwing `CatalystDataStoreError` otherwise.
  - Sends a `POST /query` request with `{ query: query_string, OLAP: true }` payload and the ZCQL `Accept` header.
  - Returns the resulting rows as `Array<ICatalystZCQLResult>`.
  - Includes JSDoc with usage example.
- Version bumps and changelog updates (`package.json`, `CHANGELOG.md` for root, `auth`, `auth-admin`, `stratus`) picked up from merging `main`.

### Usage
```ts
const datastore = new Datastore();
const rows = await datastore.executeOLAPQuery(
  "SELECT * FROM Users WHERE status = 'active'"
);
```
### Checklist
- [x] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [x] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
