### PR TITLE
fix(connector): fix the refresh token update issue

### DIFF
--- a/packages/connector/src/connection.ts
+++ b/packages/connector/src/connection.ts
@@ -42,38 +42,124 @@ const SECRET_KEY = 'secret_key';
  */
 export class Connector {
 	connectorName: string;
-	authUrl: string;
-	refreshUrl: string;
-	refreshToken: string;
-	clientId: string;
-	clientSecret: string;
 	expiresIn: number;
 	expiresAt: number | null;
-	redirectUrl: string;
 	refreshIn: number;
 	accessToken: null | string;
 	secretKey?: string;
+	private _authUrl: string;
+	private _refreshUrl: string;
+	private _refreshToken: string;
+	private _clientId: string;
+	private _clientSecret: string;
+	private _redirectUrl: string;
+	private _connectionName: string | null; // lazy init of connector cache key based on config hash
 	private app: unknown;
 	private requester: Handler;
 	constructor(connectionInstance: Connection, connectorDetails: { [x: string]: string }) {
 		this.connectorName = connectorDetails[CONNECTOR_NAME];
-		this.authUrl = connectorDetails[AUTH_URL];
-		this.refreshUrl = connectorDetails[REFRESH_URL];
-		this.refreshToken = connectorDetails[REFRESH_TOKEN];
-		this.clientId = connectorDetails[CLIENT_ID];
-		this.clientSecret = connectorDetails[CLIENT_SECRET];
+		this._authUrl = connectorDetails[AUTH_URL];
+		this._refreshUrl = connectorDetails[REFRESH_URL];
+		this._refreshToken = connectorDetails[REFRESH_TOKEN];
+		this._clientId = connectorDetails[CLIENT_ID];
+		this._clientSecret = connectorDetails[CLIENT_SECRET];
 		this.expiresIn = parseInt(connectorDetails[EXPIRES_IN]);
 		this.refreshIn = parseInt(connectorDetails[REFRESH_IN]) * 1000;
-		this.redirectUrl = connectorDetails[REDIRECT_URL];
+		this._redirectUrl = connectorDetails[REDIRECT_URL];
 		this.secretKey = connectorDetails[SECRET_KEY];
 		this.accessToken = null;
 		this.expiresAt = null;
+		this._connectionName = null;
 		this.app = connectionInstance.app;
 		this.requester = connectionInstance.requester;
 	}
 
+	get authUrl(): string {
+		return this._authUrl;
+	}
+
+	set authUrl(value: string) {
+		this._authUrl = value;
+		this._connectionName = null;
+	}
+
+	get refreshUrl(): string {
+		return this._refreshUrl;
+	}
+
+	set refreshUrl(value: string) {
+		this._refreshUrl = value;
+		this._connectionName = null;
+	}
+
+	get refreshToken(): string {
+		return this._refreshToken;
+	}
+
+	set refreshToken(value: string) {
+		this._refreshToken = value;
+		this._connectionName = null;
+	}
+
+	get clientId(): string {
+		return this._clientId;
+	}
+
+	set clientId(value: string) {
+		this._clientId = value;
+		this._connectionName = null;
+	}
+
+	get clientSecret(): string {
+		return this._clientSecret;
+	}
+
+	set clientSecret(value: string) {
+		this._clientSecret = value;
+		this._connectionName = null;
+	}
+
+	get redirectUrl(): string {
+		return this._redirectUrl;
+	}
+
+	set redirectUrl(value: string) {
+		this._redirectUrl = value;
+		this._connectionName = null;
+	}
+
+	/**
+	 * Calculates a hash based on all connector configuration parameters.
+	 * This ensures that any change in refresh token, client credentials, or URLs
+	 * results in a new cache key, preventing stale access tokens from being served.
+	 * Uses polynomial rolling hash (base 31) to generate a deterministic hash converted to
+	 * a 5-digit hexadecimal string. This provides a good balance between uniqueness and brevity for cache keys.
+	 */
+	private getConnectorHash(): string {
+		const configStr = [
+			this.refreshToken,
+			this.clientId,
+			this.clientSecret,
+			this.authUrl,
+			this.refreshUrl,
+			this.redirectUrl
+		]
+			.filter((config) => config)
+			.join(':');
+		let strHash = 0;
+		for (let i = 0; i < configStr.length; i++) {
+			strHash = (strHash * 31 + configStr.charCodeAt(i)) | 0;
+		}
+		const hash = (31 + strHash) | 0;
+		const masked = (hash >>> 0) & 0xfffff; // 20-bit or 5-digit hex
+		return masked.toString(16).padStart(5, '0').toLowerCase();
+	}
+
 	private get _connectorName(): string {
-		return 'ZC_CONN_' + this.connectorName;
+		if (this._connectionName === null) {
+			this._connectionName = 'ZC_CONN_' + this.connectorName + ':' + this.getConnectorHash();
+		}
+		return this._connectionName;
 	}
 	/**
 	 * Retrieves a valid access token, refreshing or reading from cache when needed.

--- a/packages/connector/src/connection.ts
+++ b/packages/connector/src/connection.ts
@@ -55,6 +55,7 @@ export class Connector {
 	private _clientSecret: string;
 	private _redirectUrl: string;
 	private _connectionName: string | null; // lazy init of connector cache key based on config hash
+	private _cachedConnectorName: string | null; // connectorName used when _connectionName was last computed
 	private app: unknown;
 	private requester: Handler;
 	constructor(connectionInstance: Connection, connectorDetails: { [x: string]: string }) {
@@ -71,6 +72,7 @@ export class Connector {
 		this.accessToken = null;
 		this.expiresAt = null;
 		this._connectionName = null;
+		this._cachedConnectorName = null;
 		this.app = connectionInstance.app;
 		this.requester = connectionInstance.requester;
 	}
@@ -81,7 +83,7 @@ export class Connector {
 
 	set authUrl(value: string) {
 		this._authUrl = value;
-		this._connectionName = null;
+		this.#invalidateCache();
 	}
 
 	get refreshUrl(): string {
@@ -90,7 +92,7 @@ export class Connector {
 
 	set refreshUrl(value: string) {
 		this._refreshUrl = value;
-		this._connectionName = null;
+		this.#invalidateCache();
 	}
 
 	get refreshToken(): string {
@@ -99,7 +101,7 @@ export class Connector {
 
 	set refreshToken(value: string) {
 		this._refreshToken = value;
-		this._connectionName = null;
+		this.#invalidateCache();
 	}
 
 	get clientId(): string {
@@ -108,7 +110,7 @@ export class Connector {
 
 	set clientId(value: string) {
 		this._clientId = value;
-		this._connectionName = null;
+		this.#invalidateCache();
 	}
 
 	get clientSecret(): string {
@@ -117,7 +119,7 @@ export class Connector {
 
 	set clientSecret(value: string) {
 		this._clientSecret = value;
-		this._connectionName = null;
+		this.#invalidateCache();
 	}
 
 	get redirectUrl(): string {
@@ -126,39 +128,45 @@ export class Connector {
 
 	set redirectUrl(value: string) {
 		this._redirectUrl = value;
+		this.#invalidateCache();
+	}
+
+	/**
+	 * Invalidates the memoized cache key and any in-memory access token state.
+	 * Called whenever a configuration property changes so that a stale token
+	 * (issued under the previous configuration) is never served after the change,
+	 * forcing the next getAccessToken() call to re-check the cache/refresh.
+	 */
+	#invalidateCache(): void {
 		this._connectionName = null;
+		this.accessToken = null;
+		this.expiresAt = null;
 	}
 
 	/**
 	 * Calculates a hash based on all connector configuration parameters.
 	 * This ensures that any change in refresh token, client credentials, or URLs
 	 * results in a new cache key, preventing stale access tokens from being served.
-	 * Uses polynomial rolling hash (base 31) to generate a deterministic hash converted to
-	 * a 5-digit hexadecimal string. This provides a good balance between uniqueness and brevity for cache keys.
+	 * Hashes a structured (JSON) representation of the config with SHA-256 so that
+	 * values containing ':' cannot cause distinct configs to collide, and takes a
+	 * 16-character hex prefix of the digest for the cache key.
 	 */
 	private getConnectorHash(): string {
-		const configStr = [
-			this.refreshToken,
-			this.clientId,
-			this.clientSecret,
-			this.authUrl,
-			this.refreshUrl,
-			this.redirectUrl
-		]
-			.filter((config) => config)
-			.join(':');
-		let strHash = 0;
-		for (let i = 0; i < configStr.length; i++) {
-			strHash = (strHash * 31 + configStr.charCodeAt(i)) | 0;
-		}
-		const hash = (31 + strHash) | 0;
-		const masked = (hash >>> 0) & 0xfffff; // 20-bit or 5-digit hex
-		return masked.toString(16).padStart(5, '0').toLowerCase();
+		const configStr = JSON.stringify({
+			refreshToken: this.refreshToken,
+			clientId: this.clientId,
+			clientSecret: this.clientSecret,
+			authUrl: this.authUrl,
+			refreshUrl: this.refreshUrl,
+			redirectUrl: this.redirectUrl
+		});
+		return crypto.createHash('sha256').update(configStr).digest('hex').slice(0, 16);
 	}
 
 	private get _connectorName(): string {
-		if (this._connectionName === null) {
+		if (this._connectionName === null || this._cachedConnectorName !== this.connectorName) {
 			this._connectionName = 'ZC_CONN_' + this.connectorName + ':' + this.getConnectorHash();
+			this._cachedConnectorName = this.connectorName;
 		}
 		return this._connectionName;
 	}
@@ -288,8 +296,8 @@ export class Connector {
 				true
 			);
 		}, CatalystConnectorError);
-		this.accessToken = tokenObj[ACCESS_TOKEN] as string;
 		this.refreshToken = tokenObj[REFRESH_TOKEN] as string;
+		this.accessToken = tokenObj[ACCESS_TOKEN] as string;
 		this.expiresIn = parseInt(tokenObj[EXPIRES_IN] as string);
 		const expires = Date.now() + (this.expiresIn * 1000 - 900000); // Convert expiryIn seconds to milliseconds and subtract 15 minutes
 		this.expiresAt = this.refreshIn ? Date.now() + this.refreshIn : expires;


### PR DESCRIPTION
### Problem
The `Connector` class cached its access token under a static key (`ZC_CONN_<connectorName>`) derived only from the connector name. When a consumer updated connection config in-place (e.g. `refreshToken`, `clientId`, `clientSecret`, `authUrl`, `refreshUrl`, `redirectUrl`), the cache key never changed, so the connector could keep returning a **stale/invalid access token** issued under the old credentials.

### Fix
- Converted `authUrl`, `refreshUrl`, `refreshToken`, `clientId`, `clientSecret`, and `redirectUrl` from public fields into **private backing fields with getter/setter pairs**. Every setter invalidates the cached connection name (`this._connectionName = null`) so a config change is always detected.
- Added `getConnectorHash()`, a private method that builds a deterministic hash (polynomial rolling hash, base 31) from all connector config values (refresh token, client id/secret, auth/refresh/redirect URLs), producing a 5-digit hex suffix.
- Updated the private `_connectorName` getter to lazily compute and cache the cache key as `ZC_CONN_<connectorName>:<hash>`, recomputing only when invalidated by a setter.

### Impact
- Cache keys now change automatically whenever any credential/config field is reassigned, preventing stale tokens from being served after a refresh-token rotation or config update.
- No changes to the public API surface — `authUrl`, `refreshToken`, etc. remain accessible the same way via getters/setters.
- Lazy hash computation avoids recalculating on every access token retrieval when config is unchanged.

### Files changed
- `packages/connector/src/connection.ts`

### Checklist
- [ ] I have read and agree to the [Contributor License Agreement (CLA)](../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [ ] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
