### PR TITLE
feat(Auth): add popup sigin support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "lint-staged": {
     "**/*.{js,ts,jsx,tsx}": "eslint --fix"
   },
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm",
   "engines": {
     "node": ">=20"
   },

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zcatalyst/auth-client",
-  "version": "0.0.3",
+  "version": "0.0.3-beta-login",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -236,6 +236,11 @@ export async function collectZCRFToken(): Promise<unknown> {
 export { Auth_Protocol, ConfigStore };
 export * from './utils/constants';
 export {
+	clearOAuthTokenFromIDB,
+	getOAuthTokenFromIDB,
+	setOAuthTokenInIDB
+} from './utils/idb-token';
+export {
 	clearStratusJwt,
 	getStratusJwtExpiry,
 	getStratusSessionVersion,

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -29,7 +29,22 @@ import { CatalystConfig } from './utils/interfaces';
 import { syncProjectSession } from './utils/session';
 
 /**
+ * Shared in-flight promise for the `/sdk/init` fetch.
+ *
+ * If `getCredentials()` is called multiple times before the first call
+ * resolves (e.g. constructor fire-and-forget races with an explicit
+ * `await zcAuth.init()` call), all callers share the same Promise so
+ * only ONE network request is ever made. Once the promise settles it is
+ * cleared so the next explicit call (e.g. after sign-out) triggers a
+ * fresh fetch.
+ */
+let _credentialsPromise: Promise<void> | null = null;
+
+/**
  * Fetches browser project credentials and stores them for Catalyst client authentication.
+ * Multiple simultaneous callers are coalesced — only one `/sdk/init` request
+ * is ever in-flight at a time. All callers await the same promise and receive
+ * the result once it resolves.
  *
  * @returns The get credentials result.
  * @throws {CatalystAuthError} when credentials or authentication state are invalid.
@@ -40,52 +55,70 @@ import { syncProjectSession } from './utils/session';
  * await getCredentials();
  * ```
  */
-export async function getCredentials(): Promise<void> {
-	try {
-		setDefaultProjectConfig();
-		const response = await fetch(`/${URL_DIVIDER.RESERVED_URL}/sdk/init`, {
-			headers: {
-				Accept: 'application/json'
-			}
-		});
-
-		const credentials = await response.json();
-
-		// Handle nested credential structure
-		const finalCredentials = credentials.hasOwnProperty('credentialQR')
-			? (credentials.credentialQR as CatalystConfig)
-			: credentials;
-
-		// Validate required properties
-		validateRequiredCredentials(finalCredentials);
-
-		ConfigStore.set(
-			STRATUS_DOMAIN,
-			`-${finalCredentials.environment}${finalCredentials.stratus_suffix}`
-		);
-		ConfigStore.set(API_DOMAIN, finalCredentials.api_domain);
-		ConfigStore.set(ZAID, finalCredentials.zaid);
-		ConfigStore.set(PROJECT_ID, finalCredentials.project_id);
-		ConfigStore.set(IAM_DOMAIN, finalCredentials.auth_domain);
-		ConfigStore.set(ENVIRONMENT, finalCredentials.environment);
-		ConfigStore.set(IS_APPSAIL, finalCredentials.is_appsail);
-		ConfigStore.set(PROJECT_DOMAIN, finalCredentials.project_domain);
-		if (finalCredentials.org_id) {
-			ConfigStore.set(ORG_ID, finalCredentials.org_id);
-		}
-		ConfigStore.set(INITIALIZED, true + '');
-		setGlobal('__catalyst', finalCredentials);
-
-		// Clear stratus_jwt only when the project session actually changed so
-		// same-project reloads keep the cached cookie valid.
-		syncProjectSession(finalCredentials);
-	} catch (error) {
-		throw new CatalystAuthError(
-			'CREDENTIAL_FETCH_ERROR',
-			`Failed to fetch credentials: ${error instanceof Error ? error.message : 'Unknown error'}`,
-			500
-		);
+export function getCredentials(): Promise<void> {
+	// If a fetch is already in-flight, return the same promise so all callers
+	// wait for the single request — no duplicate /sdk/init calls, no race
+	// where a second caller reads undefined from ConfigStore mid-fetch.
+	if (_credentialsPromise !== null) {
+		return _credentialsPromise;
 	}
+
+	_credentialsPromise = (async (): Promise<void> => {
+		try {
+			setDefaultProjectConfig();
+			const response = await fetch(`/${URL_DIVIDER.RESERVED_URL}/sdk/init`, {
+				headers: {
+					Accept: 'application/json'
+				}
+			});
+
+			const credentials = await response.json();
+
+			// Handle nested credential structure
+			const finalCredentials = credentials.hasOwnProperty('credentialQR')
+				? (credentials.credentialQR as CatalystConfig)
+				: credentials;
+
+			// Validate required properties
+			validateRequiredCredentials(finalCredentials);
+
+			ConfigStore.set(
+				STRATUS_DOMAIN,
+				`-${finalCredentials.environment}${finalCredentials.stratus_suffix}`
+			);
+			ConfigStore.set(API_DOMAIN, finalCredentials.api_domain);
+			ConfigStore.set(ZAID, finalCredentials.zaid);
+			ConfigStore.set(PROJECT_ID, finalCredentials.project_id);
+			ConfigStore.set(IAM_DOMAIN, finalCredentials.auth_domain);
+			ConfigStore.set(ENVIRONMENT, finalCredentials.environment);
+			ConfigStore.set(IS_APPSAIL, finalCredentials.is_appsail);
+			ConfigStore.set(PROJECT_DOMAIN, finalCredentials.project_domain);
+			if (finalCredentials.org_id) {
+				ConfigStore.set(ORG_ID, finalCredentials.org_id);
+			}
+			ConfigStore.set(INITIALIZED, true + '');
+			setGlobal('__catalyst', finalCredentials);
+
+			// Clear stratus_jwt only when the project session actually changed so
+			// same-project reloads keep the cached cookie valid.
+			syncProjectSession(finalCredentials);
+		} catch (error) {
+			// Clear the promise on failure so the next caller triggers a fresh fetch
+			// rather than re-awaiting a permanently rejected promise.
+			_credentialsPromise = null;
+			throw new CatalystAuthError(
+				'CREDENTIAL_FETCH_ERROR',
+				`Failed to fetch credentials: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				500
+			);
+		} finally {
+			// Once resolved successfully, clear the cached promise so an explicit
+			// re-init (e.g. after sign-out) always fetches fresh credentials.
+			_credentialsPromise = null;
+		}
+	})();
+
+	return _credentialsPromise;
 }
 
 /**

--- a/packages/auth-client/src/utils/constants.ts
+++ b/packages/auth-client/src/utils/constants.ts
@@ -98,6 +98,8 @@ export const JWT_COOKIE_PREFIX = 'JWT_AUTH';
 export const JWT_COOKIE_EXPIRY_PREFIX = 'JWT_EXPIRES_AT';
 export const TOKEN_GRANT_TYPE = 'refresh_token';
 export const AUTH_TOKEN_PREFIX = 'Bearer';
+export const IDB_DB_NAME = 'zcatalyst_auth';
+export const IDB_TOKEN_KEY = 'zcatalyst_client_token';
 
 // =============================================================================
 // PROJECT & APPLICATION CONSTANTS

--- a/packages/auth-client/src/utils/enums.ts
+++ b/packages/auth-client/src/utils/enums.ts
@@ -1,4 +1,5 @@
 export enum Auth_Protocol {
 	ZcrfTokenProtocol = 'ZcrfTokenProtocol',
-	JwtTokenProtocol = 'JwtTokenProtocol'
+	JwtTokenProtocol = 'JwtTokenProtocol',
+	OAuthTokenProtocol = 'OAuthTokenProtocol'
 }

--- a/packages/auth-client/src/utils/idb-token.ts
+++ b/packages/auth-client/src/utils/idb-token.ts
@@ -1,0 +1,65 @@
+import { IDB_DB_NAME, IDB_TOKEN_KEY } from './constants';
+
+export interface IDBTokenValue {
+	token: string;
+	exp: number;
+}
+
+function openTokenDatabase(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		if (typeof indexedDB === 'undefined') {
+			reject(new Error('IndexedDB is not available in this environment.'));
+			return;
+		}
+
+		const request = indexedDB.open(IDB_DB_NAME, 1);
+		request.onupgradeneeded = () => {
+			const db = request.result;
+			if (!db.objectStoreNames.contains(IDB_DB_NAME)) {
+				db.createObjectStore(IDB_DB_NAME);
+			}
+		};
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error ?? new Error('Failed to open IndexedDB.'));
+	});
+}
+
+function withStore<T>(
+	mode: IDBTransactionMode,
+	handler: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+	return openTokenDatabase().then(
+		(db) =>
+			new Promise<T>((resolve, reject) => {
+				const transaction = db.transaction(IDB_DB_NAME, mode);
+				const store = transaction.objectStore(IDB_DB_NAME);
+				const request = handler(store);
+
+				request.onsuccess = () => resolve(request.result);
+				request.onerror = () =>
+					reject(request.error ?? new Error('IndexedDB request failed.'));
+				transaction.oncomplete = () => db.close();
+				transaction.onerror = () => {
+					db.close();
+					reject(transaction.error ?? new Error('IndexedDB transaction failed.'));
+				};
+			})
+	);
+}
+
+export async function setOAuthTokenInIDB(token: string, exp: number): Promise<void> {
+	await withStore('readwrite', (store) => store.put({ token, exp }, IDB_TOKEN_KEY));
+}
+
+export async function getOAuthTokenFromIDB(): Promise<IDBTokenValue | null> {
+	const stored = (await withStore('readonly', (store) => store.get(IDB_TOKEN_KEY))) as
+		IDBTokenValue | undefined;
+	if (!stored || typeof stored.token !== 'string' || typeof stored.exp !== 'number') {
+		return null;
+	}
+	return stored;
+}
+
+export async function clearOAuthTokenFromIDB(): Promise<void> {
+	await withStore('readwrite', (store) => store.delete(IDB_TOKEN_KEY));
+}

--- a/packages/auth-client/tests/index.test.ts
+++ b/packages/auth-client/tests/index.test.ts
@@ -1,14 +1,96 @@
 import { ConfigStore } from '../src/config-store';
-import { collectZCRFToken, getCredentials, setDefaultProjectConfig } from '../src/index';
+import {
+	clearOAuthTokenFromIDB,
+	collectZCRFToken,
+	getCredentials,
+	getOAuthTokenFromIDB,
+	setDefaultProjectConfig,
+	setOAuthTokenInIDB
+} from '../src/index';
 import { CSRF_TOKEN, INITIALIZED, PROJECT_ID, ZAID } from '../src/utils/constants';
 
 // Mock fetch globally
 global.fetch = jest.fn() as jest.Mock;
 
 describe('auth-client index', () => {
+	const idbStore = new Map();
+
+	function setupIndexedDBMock() {
+		(global as unknown as { indexedDB: unknown }).indexedDB = {
+			open: jest.fn(() => {
+				const request: any = {
+					result: {
+						objectStoreNames: {
+							contains: () => true
+						},
+						createObjectStore: jest.fn(),
+						transaction: (_storeName: string, _mode: string) => {
+							const transaction: any = {};
+							const store = {
+								get: (key: string) => {
+									const idbRequest: any = {};
+									queueMicrotask(() => {
+										idbRequest.result = idbStore.get(key);
+										idbRequest.onsuccess?.(new Event('success'));
+										transaction.oncomplete?.(new Event('complete'));
+									});
+									return idbRequest;
+								},
+								put: (value: unknown, key: string) => {
+									const idbRequest: any = {};
+									queueMicrotask(() => {
+										idbStore.set(key, value);
+										idbRequest.result = undefined;
+										idbRequest.onsuccess?.(new Event('success'));
+										transaction.oncomplete?.(new Event('complete'));
+									});
+									return idbRequest;
+								},
+								delete: (key: string) => {
+									const idbRequest: any = {};
+									queueMicrotask(() => {
+										idbStore.delete(key);
+										idbRequest.result = undefined;
+										idbRequest.onsuccess?.(new Event('success'));
+										transaction.oncomplete?.(new Event('complete'));
+									});
+									return idbRequest;
+								}
+							};
+
+							return {
+								objectStore: () => store,
+								set oncomplete(handler: unknown) {
+									transaction.oncomplete = handler;
+								},
+								get oncomplete() {
+									return transaction.oncomplete;
+								},
+								set onerror(handler: unknown) {
+									transaction.onerror = handler;
+								},
+								get onerror() {
+									return transaction.onerror;
+								},
+								error: null
+							};
+						},
+						close: jest.fn()
+					}
+				};
+				queueMicrotask(() => {
+					request.onsuccess?.(new Event('success'));
+				});
+				return request;
+			})
+		};
+	}
+
 	beforeEach(() => {
 		ConfigStore.clear();
 		(global.fetch as jest.Mock).mockClear();
+		idbStore.clear();
+		setupIndexedDBMock();
 	});
 
 	describe('setDefaultProjectConfig', () => {
@@ -86,6 +168,24 @@ describe('auth-client index', () => {
 			document.cookie = '';
 
 			await expect(collectZCRFToken()).resolves.not.toThrow();
+		});
+	});
+
+	describe('OAuth IndexedDB token helpers', () => {
+		it('should store and read the OAuth token from IndexedDB', async () => {
+			await setOAuthTokenInIDB('oauth-token', 12345);
+
+			await expect(getOAuthTokenFromIDB()).resolves.toEqual({
+				token: 'oauth-token',
+				exp: 12345
+			});
+		});
+
+		it('should clear the OAuth token from IndexedDB', async () => {
+			await setOAuthTokenInIDB('oauth-token', 12345);
+			await clearOAuthTokenFromIDB();
+
+			await expect(getOAuthTokenFromIDB()).resolves.toBeNull();
 		});
 	});
 });

--- a/packages/auth/jest.config.js
+++ b/packages/auth/jest.config.js
@@ -9,9 +9,21 @@ module.exports = {
   displayName: '@zcatalyst/auth',
   rootDir: '.',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', {
+      isolatedModules: true,
+      diagnostics: false,
+      tsconfig: {
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        jsx: 'react'
+      }
+    }]
+  },
   moduleNameMapper: {
     "^@zcatalyst/utils$": "<rootDir>/../../packages/utils/src",
     "^@zcatalyst/auth-admin$": "<rootDir>/../../packages/auth-admin/src",
+    "^@zcatalyst/auth-client$": "<rootDir>/../../packages/auth-client/src",
     "^@zcatalyst/transport$": "<rootDir>/../../packages/transport/src/__mocks__"
   }
 };

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zcatalyst/auth",
-  "version": "0.0.3",
+  "version": "0.0.3-beta-login",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
@@ -60,9 +60,9 @@
   },
   "dependencies": {
     "@zcatalyst/auth-admin": "workspace:^",
-    "@zcatalyst/transport": "workspace:^",
+    "@zcatalyst/transport": "workspace:*",
     "@zcatalyst/utils": "workspace:^",
-    "@zcatalyst/auth-client": "workspace:^"
+    "@zcatalyst/auth-client": "workspace:*"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/auth/src/utils/browser.ts
+++ b/packages/auth/src/utils/browser.ts
@@ -1,0 +1,3 @@
+export function isIframeContext(): boolean {
+	return typeof window !== 'undefined' && window.self !== window.top;
+}

--- a/packages/auth/src/utils/constants.ts
+++ b/packages/auth/src/utils/constants.ts
@@ -14,6 +14,17 @@ export const URL_DIVIDER = {
 	LOGIN: 'login'
 };
 
+export const POPUP_LOGIN_PATH = '/__catalyst/auth/login/popup';
+export const POPUP_LOGOUT_PATH = '/__catalyst/auth/logout/popup';
+export const POPUP_MSG_AUTH_REQUEST = 'catalyst-auth-request';
+export const POPUP_MSG_AUTH_TOKEN = 'catalyst-auth-token';
+export const POPUP_MSG_SIGNOUT_DONE = 'catalyst-signout-done';
+export const POPUP_MSG_AUTH_ERROR = 'catalyst-auth-error';
+export const POPUP_POLL_INTERVAL_MS = 500;
+export const POPUP_DEFAULT_TIMEOUT_MS = 120_000;
+export const POPUP_DEFAULT_WIDTH = 600;
+export const POPUP_DEFAULT_HEIGHT = 700;
+
 export const UM_QUERY_STRING = {
 	EMAIL_ID: 'emailId'
 };

--- a/packages/auth/src/utils/constants.ts
+++ b/packages/auth/src/utils/constants.ts
@@ -22,6 +22,7 @@ export const POPUP_MSG_SIGNOUT_DONE = 'catalyst-signout-done';
 export const POPUP_MSG_AUTH_ERROR = 'catalyst-auth-error';
 export const POPUP_POLL_INTERVAL_MS = 500;
 export const POPUP_DEFAULT_TIMEOUT_MS = 120_000;
+export const POPUP_DEFAULT_IS_HOSTED = false;
 export const POPUP_DEFAULT_WIDTH = 600;
 export const POPUP_DEFAULT_HEIGHT = 700;
 

--- a/packages/auth/src/utils/enums.ts
+++ b/packages/auth/src/utils/enums.ts
@@ -1,4 +1,5 @@
 export enum Auth_Protocol {
-	ZcrfTokenProtocol,
-	JwtTokenProtocol
+	ZcrfTokenProtocol = 'ZcrfTokenProtocol',
+	JwtTokenProtocol = 'JwtTokenProtocol',
+	OAuthTokenProtocol = 'OAuthTokenProtocol'
 }

--- a/packages/auth/src/utils/interface.ts
+++ b/packages/auth/src/utils/interface.ts
@@ -106,6 +106,18 @@ export interface ICatalystPopupSignInResult {
 	event_id: string;
 }
 
+export interface ICatalystDeliverAuthTokenConfig {
+	access_token?: string;
+	expires_in_sec?: number;
+	eventId?: string;
+	targetOrigin?: string;
+	feature?: 'functions' | 'stratus';
+}
+
+export interface ICatalystDeliverSignOutDoneConfig {
+	targetOrigin?: string;
+}
+
 export interface IPopupAuthOperation {
 	eventId: string;
 	status: 'waiting' | 'completed' | 'cancelled' | 'expired';

--- a/packages/auth/src/utils/interface.ts
+++ b/packages/auth/src/utils/interface.ts
@@ -90,12 +90,14 @@ export interface ICatalystSignInConfig {
 	popupWidth?: number;
 	popupHeight?: number;
 	popupTimeoutMs?: number;
+	isHosted?: boolean;
 }
 
 export interface ICatalystPopupSignInConfig {
 	width?: number;
 	height?: number;
 	timeoutMs?: number;
+	isHosted?: boolean;
 }
 
 export interface ICatalystPopupSignInResult {

--- a/packages/auth/src/utils/interface.ts
+++ b/packages/auth/src/utils/interface.ts
@@ -87,6 +87,28 @@ export interface ICatalystSignInConfig {
 	forgotPasswordCssUrl?: string;
 	serviceUrl?: string;
 	redirectUrl?: string;
+	popupWidth?: number;
+	popupHeight?: number;
+	popupTimeoutMs?: number;
+}
+
+export interface ICatalystPopupSignInConfig {
+	width?: number;
+	height?: number;
+	timeoutMs?: number;
+}
+
+export interface ICatalystPopupSignInResult {
+	access_token: string;
+	expires_at: number;
+	event_id: string;
+}
+
+export interface IPopupAuthOperation {
+	eventId: string;
+	status: 'waiting' | 'completed' | 'cancelled' | 'expired';
+	popup: Window | null;
+	createdAt: number;
 }
 
 export interface ICatalystAuthResponse {

--- a/packages/auth/src/utils/popup-auth.ts
+++ b/packages/auth/src/utils/popup-auth.ts
@@ -3,7 +3,8 @@ import {
 	POPUP_DEFAULT_WIDTH,
 	POPUP_LOGIN_PATH,
 	POPUP_LOGOUT_PATH,
-	POPUP_MSG_AUTH_TOKEN
+	POPUP_MSG_AUTH_TOKEN,
+	POPUP_MSG_SIGNOUT_DONE
 } from './constants';
 import { CatalystAuthenticationError } from './error';
 
@@ -64,6 +65,18 @@ export function deliverAuthTokenToParent({
 			eventId: resolvedEventId,
 			access_token,
 			expires_in_sec
+		},
+		targetOrigin ?? window.location.origin
+	);
+}
+
+export function deliverSignOutDoneToParent(targetOrigin?: string): void {
+	if (typeof window === 'undefined' || !window.opener || window.opener.closed) {
+		throw new Error('Parent window is not available.');
+	}
+	window.opener.postMessage(
+		{
+			type: POPUP_MSG_SIGNOUT_DONE
 		},
 		targetOrigin ?? window.location.origin
 	);

--- a/packages/auth/src/utils/popup-auth.ts
+++ b/packages/auth/src/utils/popup-auth.ts
@@ -98,8 +98,8 @@ export function openPopupWindow({
 	return popup;
 }
 
-export function buildPopupLoginUrl(origin: string, eventId: string): string {
-	return `${origin}${POPUP_LOGIN_PATH}/${eventId}?embedded=true`;
+export function buildPopupLoginUrl(origin: string, eventId: string, hosted: boolean): string {
+	return `${origin}${POPUP_LOGIN_PATH}/${eventId}?hosted=${hosted}`;
 }
 
 export function buildPopupLogoutUrl(origin: string): string {

--- a/packages/auth/src/utils/popup-auth.ts
+++ b/packages/auth/src/utils/popup-auth.ts
@@ -1,0 +1,107 @@
+import {
+	POPUP_DEFAULT_HEIGHT,
+	POPUP_DEFAULT_WIDTH,
+	POPUP_LOGIN_PATH,
+	POPUP_LOGOUT_PATH,
+	POPUP_MSG_AUTH_TOKEN
+} from './constants';
+import { CatalystAuthenticationError } from './error';
+
+export interface PopupWindowOptions {
+	width?: number;
+	height?: number;
+	name: string;
+	url: string;
+}
+
+export interface DeliverAuthTokenOptions {
+	access_token: string;
+	expires_in_sec: number;
+	eventId?: string;
+	targetOrigin?: string;
+}
+
+export function createPopupEventId(): string {
+	return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+		? crypto.randomUUID()
+		: 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+				const rand = (Math.random() * 16) | 0;
+				return (char === 'x' ? rand : (rand & 0x3) | 0x8).toString(16);
+			});
+}
+
+export function resolvePopupEventId(eventId?: string): string {
+	if (eventId) {
+		return eventId;
+	}
+	if (typeof window === 'undefined') {
+		throw new Error('eventId is not present');
+	}
+	const pathnameEventId = window.location.pathname.split('/').pop();
+	if (pathnameEventId) {
+		return pathnameEventId;
+	}
+	const searchEventId = new URLSearchParams(window.location.search).get('eventId');
+	if (searchEventId) {
+		return searchEventId;
+	}
+	throw new Error('eventId is not present');
+}
+
+export function deliverAuthTokenToParent({
+	access_token,
+	expires_in_sec,
+	eventId,
+	targetOrigin
+}: DeliverAuthTokenOptions): void {
+	if (typeof window === 'undefined' || !window.opener || window.opener.closed) {
+		throw new Error('Parent window is not available.');
+	}
+	const resolvedEventId = resolvePopupEventId(eventId);
+	window.opener.postMessage(
+		{
+			type: POPUP_MSG_AUTH_TOKEN,
+			eventId: resolvedEventId,
+			access_token,
+			expires_in_sec
+		},
+		targetOrigin ?? window.location.origin
+	);
+}
+
+export function openPopupWindow({
+	url,
+	name,
+	width = POPUP_DEFAULT_WIDTH,
+	height = POPUP_DEFAULT_HEIGHT
+}: PopupWindowOptions): Window {
+	const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
+	const top = Math.round(window.screenY + (window.outerHeight - height) / 2);
+	const features = [
+		`width=${width}`,
+		`height=${height}`,
+		`left=${left}`,
+		`top=${top}`,
+		'location=yes',
+		'resizable=yes',
+		'scrollbars=yes',
+		'status=yes',
+		'toolbar=no'
+	].join(',');
+	const popup = window.open(url, name, features);
+	if (!popup) {
+		throw new CatalystAuthenticationError(
+			'POPUP_BLOCKED',
+			'Popup was blocked by the browser. Please allow popups for this site and try again.'
+		);
+	}
+	return popup;
+}
+
+export function buildPopupLoginUrl(origin: string, eventId: string): string {
+	return `${origin}${POPUP_LOGIN_PATH}/${eventId}?embedded=true`;
+}
+
+export function buildPopupLogoutUrl(origin: string): string {
+	return `${origin}${POPUP_LOGOUT_PATH}`;
+}

--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -96,6 +96,7 @@ class Authentication implements Component {
 	#popupPollInterval: ReturnType<typeof setInterval> | null = null;
 	#popupTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
 	#popupMessageListener: ((event: MessageEvent) => void) | null = null;
+	#tokenRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	/** Creates a browser authentication client for the provided Catalyst app. */
 	constructor(app?: unknown) {
 		this.requester = new Handler(app, this);
@@ -137,6 +138,15 @@ class Authentication implements Component {
 		// isUserAuthenticated() / signIn() / generateAuthToken() run — preventing
 		// URLs like /baas/v1/project/undefined/project-user/current in popup contexts.
 		await getCredentials();
+		// Refresh instance fields from ConfigStore after getCredentials() completes.
+		// The constructor reads ConfigStore before credentials are fetched, so fields
+		// like this.zaid and this.projectId are undefined at construction time in popup
+		// contexts where the fire-and-forget getCredentials() hasn't finished yet.
+		// Re-reading here ensures generateAuthToken() and other methods use the correct values.
+		this.zaid = ConfigStore.get('ZAID') as string;
+		this.projectId = ConfigStore.get('PROJECT_ID') as string;
+		this.isAppsail = ConfigStore.get('IS_APPSAIL') as string;
+		this.authProtocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
 		//Only inside the iframe getOAuthTokenFromIDB will return a data.
 		const storedToken = await getOAuthTokenFromIDB().catch(() => null);
 		if (storedToken && storedToken.exp > Date.now()) {
@@ -757,10 +767,33 @@ class Authentication implements Component {
 	async #setTokenStorage(accessToken: string, expiresInSec: number): Promise<number> {
 		const expiresAt = Date.now() + expiresInSec * 1000;
 		await setOAuthTokenInIDB(accessToken, expiresAt);
+		// Schedule a proactive token refresh 5 minutes before expiry.
+		// Clears any existing timer first so only one refresh is ever pending.
+		if (this.#tokenRefreshTimer !== null) {
+			clearTimeout(this.#tokenRefreshTimer);
+			this.#tokenRefreshTimer = null;
+		}
+		const refreshInMs = (expiresInSec - 5 * 60) * 1000;
+		if (refreshInMs > 0) {
+			this.#tokenRefreshTimer = setTimeout(() => {
+				this.generateAuthToken('functions')
+					.then((token) => {
+						this.#setTokenStorage(token.access_token, token.expires_in_sec);
+					})
+					.catch(() => {
+						// Refresh failed — token will be invalid when it expires;
+						// the next call requiring auth will re-trigger the popup flow.
+					});
+			}, refreshInMs);
+		}
 		return expiresAt;
 	}
 
 	async #clearTokenStorage(): Promise<void> {
+		if (this.#tokenRefreshTimer !== null) {
+			clearTimeout(this.#tokenRefreshTimer);
+			this.#tokenRefreshTimer = null;
+		}
 		await clearOAuthTokenFromIDB();
 		clearStratusJwt();
 	}

--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -29,6 +29,7 @@ import {
 	CURRENT_CLIENT_PAGE_PROTOCOL,
 	FETCH_DETAILS_CALLBACK_FN,
 	POPUP_DEFAULT_HEIGHT,
+	POPUP_DEFAULT_IS_HOSTED,
 	POPUP_DEFAULT_TIMEOUT_MS,
 	POPUP_DEFAULT_WIDTH,
 	POPUP_MSG_AUTH_ERROR,
@@ -44,6 +45,7 @@ import { CatalystAuthenticationError } from './utils/error';
 import { wrapCheck } from './utils/functions';
 import {
 	ICatalystAuthResponse,
+	ICatalystCustomTokenResponse,
 	ICatalystPopupSignInConfig,
 	ICatalystPopupSignInResult,
 	ICatalystSignInConfig,
@@ -58,6 +60,11 @@ import {
 	openPopupWindow
 } from './utils/popup-auth';
 import { applyQueryString, hasSuffInfo } from './utils/validators';
+
+type Token_responce = {
+	expires_in_sec: number;
+	access_token: string;
+};
 
 const { CREDENTIAL_USER, REQ_METHOD, COMPONENT } = CONSTANTS;
 
@@ -141,7 +148,8 @@ class Authentication implements Component {
 			await this.signInViaPopup({
 				width: config.popupWidth,
 				height: config.popupHeight,
-				timeoutMs: config.popupTimeoutMs
+				timeoutMs: config.popupTimeoutMs,
+				isHosted: config.isHosted
 			});
 			return;
 		}
@@ -759,6 +767,7 @@ class Authentication implements Component {
 		const width = config.width ?? POPUP_DEFAULT_WIDTH;
 		const height = config.height ?? POPUP_DEFAULT_HEIGHT;
 		const timeoutMs = config.timeoutMs ?? POPUP_DEFAULT_TIMEOUT_MS;
+		const isHosted = config.isHosted ?? POPUP_DEFAULT_IS_HOSTED;
 		const eventId = createPopupEventId();
 
 		return new Promise<ICatalystPopupSignInResult>((resolve, reject) => {
@@ -830,7 +839,7 @@ class Authentication implements Component {
 			window.addEventListener('message', onMessage);
 
 			const popup = openPopupWindow({
-				url: buildPopupLoginUrl(window.location.origin, eventId),
+				url: buildPopupLoginUrl(window.location.origin, eventId, isHosted),
 				name: 'catalystSignIn',
 				width,
 				height
@@ -922,6 +931,65 @@ class Authentication implements Component {
 
 			window.addEventListener('message', onMessage);
 		});
+	}
+
+	async generateAuthToken(feature: 'functions' | 'stratus'): Promise<Token_responce> {
+		const customTokenRequest: IRequestConfig = {
+			method: REQ_METHOD.get,
+			path: '/authentication/custom-token',
+			type: RequestType.JSON,
+			service: CatalystService.BAAS,
+			user: CREDENTIAL_USER.user,
+			qs: {
+				feature
+			}
+		};
+		const customTokenResp = await this.requester.send(customTokenRequest);
+		const customTokenData = customTokenResp.data.data as ICatalystCustomTokenResponse;
+
+		const remoteAuthRequest: IRequestConfig = {
+			method: REQ_METHOD.post,
+			service: CatalystService.EXTERNAL,
+			path: `/clientoauth/v2/${this.zaid}/remote/auth`,
+			origin: ConfigStore.get('IAM_DOMAIN') as string,
+			auth: false,
+			headers: {
+				Origin: window.location.origin
+			},
+			qs: {
+				response_type: 'remote_token',
+				scope: customTokenData.scopes.join(' '),
+				client_id: customTokenData.client_id,
+				jwt_token: customTokenData.jwt_token
+			}
+		};
+
+		const remoteAuthResp = await this.requester.send(remoteAuthRequest);
+		const remoteAuthData = remoteAuthResp.data as {
+			access_token?: string;
+			access_toke?: string;
+			expires_in_sec?: number;
+			expires_in?: number;
+		};
+
+		const accessToken = remoteAuthData.access_token ?? remoteAuthData.access_toke;
+		if (!accessToken) {
+			throw new CatalystAuthenticationError(
+				'AUTHENTICATION_ERROR',
+				'Unable to exchange JWT token for an OAuth access token.'
+			);
+		}
+
+		const expiresInSec =
+			typeof remoteAuthData.expires_in_sec === 'number'
+				? remoteAuthData.expires_in_sec
+				: typeof remoteAuthData.expires_in === 'number'
+					? remoteAuthData.expires_in
+					: 3600;
+		return {
+			access_token: accessToken,
+			expires_in_sec: expiresInSec
+		};
 	}
 }
 export { UserManagement } from './user-management';

--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -201,6 +201,14 @@ class Authentication implements Component {
 			this.isAppsail = ConfigStore.get('IS_APPSAIL') as string;
 			this.authProtocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
 		}
+
+		// Default redirect target: use caller-provided URL or fall back to the
+		// current path so the user lands back where they were after sign-in.
+		const redirectTarget =
+			config.redirectUrl ??
+			config.serviceUrl ??
+			window.location.pathname + window.location.search;
+
 		if (detectIframeContext()) {
 			await this.signInViaPopup({
 				width: config.popupWidth,
@@ -208,14 +216,14 @@ class Authentication implements Component {
 				timeoutMs: config.popupTimeoutMs,
 				isHosted: config.isHosted
 			});
+			// After popup auth completes, redirect to the intended path.
+			window.location.href = redirectTarget;
 			return;
 		}
 		try {
 			const isValidUser = await this.#isValidUser();
 			if (isValidUser) {
-				window.location.href = this.#constructRedirectUrl(
-					config.redirectUrl ?? config.serviceUrl ?? ''
-				);
+				window.location.href = this.#constructRedirectUrl(redirectTarget);
 			} else {
 				await this.#notSignedIn(id, config);
 			}

--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -20,7 +20,7 @@ import {
 
 import pkg from '../package.json';
 const { version } = pkg;
-import { isIframeContext } from './utils/browser';
+import { isIframeContext as detectIframeContext } from './utils/browser';
 import {
 	AUTH_ERROR_MSG,
 	AUTH_STATIC_FILES,
@@ -32,6 +32,8 @@ import {
 	POPUP_DEFAULT_IS_HOSTED,
 	POPUP_DEFAULT_TIMEOUT_MS,
 	POPUP_DEFAULT_WIDTH,
+	POPUP_LOGIN_PATH,
+	POPUP_LOGOUT_PATH,
 	POPUP_MSG_AUTH_ERROR,
 	POPUP_MSG_AUTH_REQUEST,
 	POPUP_MSG_AUTH_TOKEN,
@@ -46,6 +48,8 @@ import { wrapCheck } from './utils/functions';
 import {
 	ICatalystAuthResponse,
 	ICatalystCustomTokenResponse,
+	ICatalystDeliverAuthTokenConfig,
+	ICatalystDeliverSignOutDoneConfig,
 	ICatalystPopupSignInConfig,
 	ICatalystPopupSignInResult,
 	ICatalystSignInConfig,
@@ -57,6 +61,8 @@ import {
 	buildPopupLoginUrl,
 	buildPopupLogoutUrl,
 	createPopupEventId,
+	deliverAuthTokenToParent as postAuthTokenToParent,
+	deliverSignOutDoneToParent as postSignOutDoneToParent,
 	openPopupWindow
 } from './utils/popup-auth';
 import { applyQueryString, hasSuffInfo } from './utils/validators';
@@ -68,6 +74,16 @@ type Token_responce = {
 
 const { CREDENTIAL_USER, REQ_METHOD, COMPONENT } = CONSTANTS;
 
+/** Popup message-type / path constants exposed on {@link zcAuth}. */
+export const popupConstants = {
+	POPUP_LOGIN_PATH,
+	POPUP_LOGOUT_PATH,
+	POPUP_MSG_AUTH_REQUEST,
+	POPUP_MSG_AUTH_TOKEN,
+	POPUP_MSG_SIGNOUT_DONE,
+	POPUP_MSG_AUTH_ERROR
+} as const;
+
 /** Provides browser authentication flows for hosted sign-in, embedded sign-in, sign-up, and user profile access. */
 class Authentication implements Component {
 	requester: Handler;
@@ -75,6 +91,7 @@ class Authentication implements Component {
 	projectId: string = ConfigStore.get('PROJECT_ID') as string;
 	isAppsail: string = ConfigStore.get('IS_APPSAIL') as string;
 	authProtocol: Auth_Protocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
+	readonly popupConstants = popupConstants;
 	#popupAuthOperation: IPopupAuthOperation | null = null;
 	#popupPollInterval: ReturnType<typeof setInterval> | null = null;
 	#popupTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -114,11 +131,31 @@ class Authentication implements Component {
 	 * ```
 	 */
 	async init(): Promise<void> {
+		// Ensure credentials (project_id, zaid, org_id, etc.) are fetched before
+		// any auth operation. The constructor fires getCredentials() in the background
+		// (fire-and-forget), so awaiting it here guarantees project_id is set before
+		// isUserAuthenticated() / signIn() / generateAuthToken() run — preventing
+		// URLs like /baas/v1/project/undefined/project-user/current in popup contexts.
+		await getCredentials();
 		//Only inside the iframe getOAuthTokenFromIDB will return a data.
 		const storedToken = await getOAuthTokenFromIDB().catch(() => null);
 		if (storedToken && storedToken.exp > Date.now()) {
 			this.#setAuthProtocol(Auth_Protocol.OAuthTokenProtocol);
 		}
+	}
+
+	/**
+	 * Returns whether the SDK is running inside an iframe.
+	 *
+	 * @example
+	 * ```ts
+	 * if (zcAuth.isIframeContext()) {
+	 *   await zcAuth.signInViaPopup();
+	 * }
+	 * ```
+	 */
+	isIframeContext(): boolean {
+		return detectIframeContext();
 	}
 
 	/**
@@ -144,7 +181,7 @@ class Authentication implements Component {
 	 * ```
 	 */
 	async signIn(id: string, config: ICatalystSignInConfig = {}): Promise<void> {
-		if (isIframeContext()) {
+		if (detectIframeContext()) {
 			await this.signInViaPopup({
 				width: config.popupWidth,
 				height: config.popupHeight,
@@ -349,7 +386,7 @@ class Authentication implements Component {
 		setDefaultProjectConfig();
 		const authProtocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
 		this.authProtocol = authProtocol;
-		if (isIframeContext()) {
+		if (detectIframeContext()) {
 			await this.signOutViaPopup(redirectURL);
 			return;
 		}
@@ -933,6 +970,55 @@ class Authentication implements Component {
 		});
 	}
 
+	/**
+	 * Sends the OAuth access token from the popup window to the opener via postMessage.
+	 * Intended for the popup login page at `/__catalyst/auth/login/popup/{eventId}`.
+	 *
+	 * When `access_token` and `expires_in_sec` are omitted, they are fetched via
+	 * {@link generateAuthToken}. `eventId` is resolved from the popup URL when omitted.
+	 *
+	 * @param config - Token delivery configuration.
+	 * @returns A promise that resolves after the token is posted to the parent window.
+	 *
+	 * @example
+	 * ```ts
+	 * await zcAuth.init();
+	 * await zcAuth.deliverAuthTokenToParent({ targetOrigin: window.location.origin });
+	 * ```
+	 */
+	async deliverAuthTokenToParent(config: ICatalystDeliverAuthTokenConfig = {}): Promise<void> {
+		let accessToken = config.access_token;
+		let expiresInSec = config.expires_in_sec;
+
+		if (!accessToken || !expiresInSec) {
+			const token = await this.generateAuthToken(config.feature ?? 'functions');
+			accessToken = accessToken ?? token.access_token;
+			expiresInSec = expiresInSec ?? token.expires_in_sec;
+		}
+
+		postAuthTokenToParent({
+			access_token: accessToken,
+			expires_in_sec: expiresInSec,
+			eventId: config.eventId,
+			targetOrigin: config.targetOrigin
+		});
+	}
+
+	/**
+	 * Notifies the opener that popup sign-out completed.
+	 * Intended for the popup logout page at `/__catalyst/auth/logout/popup`.
+	 *
+	 * @param config - Optional target origin for postMessage.
+	 *
+	 * @example
+	 * ```ts
+	 * zcAuth.deliverSignOutDoneToParent({ targetOrigin: window.location.origin });
+	 * ```
+	 */
+	deliverSignOutDoneToParent(config: ICatalystDeliverSignOutDoneConfig = {}): void {
+		postSignOutDoneToParent(config.targetOrigin);
+	}
+
 	async generateAuthToken(feature: 'functions' | 'stratus'): Promise<Token_responce> {
 		const customTokenRequest: IRequestConfig = {
 			method: REQ_METHOD.get,
@@ -993,6 +1079,7 @@ class Authentication implements Component {
 	}
 }
 export { UserManagement } from './user-management';
+export { isIframeContext } from './utils/browser';
 export * from './utils/constants';
 
 export const zcAuth = new Authentication();

--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -1,9 +1,12 @@
 import {
+	clearOAuthTokenFromIDB,
 	clearStratusJwt,
 	ConfigStore,
 	getCredentials,
+	getOAuthTokenFromIDB,
 	JWT_COOKIE_PREFIX,
-	setDefaultProjectConfig
+	setDefaultProjectConfig,
+	setOAuthTokenInIDB
 } from '@zcatalyst/auth-client';
 import { Handler, IRequestConfig, RequestType, ResponseType } from '@zcatalyst/transport';
 import {
@@ -17,6 +20,7 @@ import {
 
 import pkg from '../package.json';
 const { version } = pkg;
+import { isIframeContext } from './utils/browser';
 import {
 	AUTH_ERROR_MSG,
 	AUTH_STATIC_FILES,
@@ -24,6 +28,14 @@ import {
 	CURRENT_CLIENT_PAGE_PORT,
 	CURRENT_CLIENT_PAGE_PROTOCOL,
 	FETCH_DETAILS_CALLBACK_FN,
+	POPUP_DEFAULT_HEIGHT,
+	POPUP_DEFAULT_TIMEOUT_MS,
+	POPUP_DEFAULT_WIDTH,
+	POPUP_MSG_AUTH_ERROR,
+	POPUP_MSG_AUTH_REQUEST,
+	POPUP_MSG_AUTH_TOKEN,
+	POPUP_MSG_SIGNOUT_DONE,
+	POPUP_POLL_INTERVAL_MS,
 	UM_URL_DIVIDER,
 	URL_DIVIDER
 } from './utils/constants';
@@ -32,10 +44,19 @@ import { CatalystAuthenticationError } from './utils/error';
 import { wrapCheck } from './utils/functions';
 import {
 	ICatalystAuthResponse,
+	ICatalystPopupSignInConfig,
+	ICatalystPopupSignInResult,
 	ICatalystSignInConfig,
 	ICatalystSignUpConfig,
+	IPopupAuthOperation,
 	UserDetails
 } from './utils/interface';
+import {
+	buildPopupLoginUrl,
+	buildPopupLogoutUrl,
+	createPopupEventId,
+	openPopupWindow
+} from './utils/popup-auth';
 import { applyQueryString, hasSuffInfo } from './utils/validators';
 
 const { CREDENTIAL_USER, REQ_METHOD, COMPONENT } = CONSTANTS;
@@ -47,6 +68,10 @@ class Authentication implements Component {
 	projectId: string = ConfigStore.get('PROJECT_ID') as string;
 	isAppsail: string = ConfigStore.get('IS_APPSAIL') as string;
 	authProtocol: Auth_Protocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
+	#popupAuthOperation: IPopupAuthOperation | null = null;
+	#popupPollInterval: ReturnType<typeof setInterval> | null = null;
+	#popupTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+	#popupMessageListener: ((event: MessageEvent) => void) | null = null;
 	/** Creates a browser authentication client for the provided Catalyst app. */
 	constructor(app?: unknown) {
 		this.requester = new Handler(app, this);
@@ -81,7 +106,13 @@ class Authentication implements Component {
 	 * await zcAuth.init();
 	 * ```
 	 */
-	async init(): Promise<void> {}
+	async init(): Promise<void> {
+		//Only inside the iframe getOAuthTokenFromIDB will return a data.
+		const storedToken = await getOAuthTokenFromIDB().catch(() => null);
+		if (storedToken && storedToken.exp > Date.now()) {
+			this.#setAuthProtocol(Auth_Protocol.OAuthTokenProtocol);
+		}
+	}
 
 	/**
 	 * Starts the embedded IAM sign-in flow inside a target DOM element or redirects an already authenticated user.
@@ -106,6 +137,14 @@ class Authentication implements Component {
 	 * ```
 	 */
 	async signIn(id: string, config: ICatalystSignInConfig = {}): Promise<void> {
+		if (isIframeContext()) {
+			await this.signInViaPopup({
+				width: config.popupWidth,
+				height: config.popupHeight,
+				timeoutMs: config.popupTimeoutMs
+			});
+			return;
+		}
 		try {
 			const isValidUser = await this.#isValidUser();
 			if (isValidUser) {
@@ -155,7 +194,7 @@ class Authentication implements Component {
 	 */
 	public signinWithJwt(callbackFn: () => void): void {
 		ConfigStore.set(FETCH_DETAILS_CALLBACK_FN, callbackFn);
-		ConfigStore.set('AUTH_PROTOCOL', Auth_Protocol.JwtTokenProtocol);
+		this.#setAuthProtocol(Auth_Protocol.JwtTokenProtocol);
 	}
 
 	/**
@@ -300,45 +339,54 @@ class Authentication implements Component {
 	 */
 	async signOut(redirectURL = '/'): Promise<void> {
 		setDefaultProjectConfig();
-		if (this.authProtocol === Auth_Protocol.JwtTokenProtocol) {
+		const authProtocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
+		this.authProtocol = authProtocol;
+		if (isIframeContext()) {
+			await this.signOutViaPopup(redirectURL);
+			return;
+		}
+		if (authProtocol === Auth_Protocol.JwtTokenProtocol) {
 			document.cookie = `${JWT_COOKIE_PREFIX}=; path=/; expires=${new Date().toUTCString()};`;
 			document.cookie = `user_cred=; path=/; expires=${new Date().toUTCString()};`;
 			clearStratusJwt();
 			// Force immediate redirect for JWT
 			window.location.replace(redirectURL);
 			return;
-		} else {
-			if (this.isAppsail === 'true') {
-				const validUser = await this.#isValidUser();
-				if (!validUser) {
-					if (redirectURL.startsWith('/')) {
-						redirectURL =
-							CURRENT_CLIENT_PAGE_PORT != ''
-								? `${CURRENT_CLIENT_PAGE_PROTOCOL}//${CURRENT_CLIENT_PAGE_HOST}:${CURRENT_CLIENT_PAGE_PORT}${redirectURL}`
-								: `${CURRENT_CLIENT_PAGE_PROTOCOL}//${CURRENT_CLIENT_PAGE_HOST}${redirectURL}`;
-					}
-					window.location.replace(redirectURL);
-					return;
+		}
+		if (authProtocol === Auth_Protocol.OAuthTokenProtocol) {
+			await this.#clearTokenStorage();
+			document.cookie = `user_cred=; path=/; expires=${new Date().toUTCString()};`;
+		}
+		if (this.isAppsail === 'true') {
+			const validUser = await this.#isValidUser();
+			if (!validUser) {
+				if (redirectURL.startsWith('/')) {
+					redirectURL =
+						CURRENT_CLIENT_PAGE_PORT != ''
+							? `${CURRENT_CLIENT_PAGE_PROTOCOL}//${CURRENT_CLIENT_PAGE_HOST}:${CURRENT_CLIENT_PAGE_PORT}${redirectURL}`
+							: `${CURRENT_CLIENT_PAGE_PROTOCOL}//${CURRENT_CLIENT_PAGE_HOST}${redirectURL}`;
 				}
+				window.location.replace(redirectURL);
+				return;
+			}
 
-				try {
-					const request: IRequestConfig = {
-						method: REQ_METHOD.get,
-						url: this.#constructSignOutUrl(redirectURL),
-						external: true
-					};
-					await this.requester.send(request);
-					document.cookie = `CAUTH=; path=/accounts; expires=${new Date().toUTCString()};`;
-					// Use replace instead of href for immediate navigation
-					window.location.replace(redirectURL);
-				} catch {
-					// Use replace for error case too
-					window.location.replace(this.#constructSignOutUrl(redirectURL));
-				}
-			} else {
+			try {
+				const request: IRequestConfig = {
+					method: REQ_METHOD.get,
+					url: this.#constructSignOutUrl(redirectURL),
+					external: true
+				};
+				await this.requester.send(request);
+				document.cookie = `CAUTH=; path=/accounts; expires=${new Date().toUTCString()};`;
 				// Use replace instead of href for immediate navigation
+				window.location.replace(redirectURL);
+			} catch {
+				// Use replace for error case too
 				window.location.replace(this.#constructSignOutUrl(redirectURL));
 			}
+		} else {
+			// Use replace instead of href for immediate navigation
+			window.location.replace(this.#constructSignOutUrl(redirectURL));
 		}
 	}
 
@@ -654,6 +702,226 @@ class Authentication implements Component {
 		};
 		const resp = await this.requester.send(request);
 		return resp.data as unknown as string;
+	}
+
+	#setAuthProtocol(protocol: Auth_Protocol): void {
+		this.authProtocol = protocol;
+		ConfigStore.set('AUTH_PROTOCOL', protocol);
+	}
+
+	async #setTokenStorage(accessToken: string, expiresInSec: number): Promise<number> {
+		const expiresAt = Date.now() + expiresInSec * 1000;
+		await setOAuthTokenInIDB(accessToken, expiresAt);
+		return expiresAt;
+	}
+
+	async #clearTokenStorage(): Promise<void> {
+		await clearOAuthTokenFromIDB();
+		clearStratusJwt();
+	}
+
+	#clearPopupOperation(status: IPopupAuthOperation['status'] = 'cancelled'): void {
+		if (this.#popupAuthOperation) {
+			this.#popupAuthOperation.status = status;
+			try {
+				if (this.#popupAuthOperation.popup && !this.#popupAuthOperation.popup.closed) {
+					this.#popupAuthOperation.popup.close();
+				}
+			} catch {
+				// ignore cross-origin close errors
+			}
+			this.#popupAuthOperation.popup = null;
+		}
+		if (this.#popupPollInterval !== null) {
+			clearInterval(this.#popupPollInterval);
+			this.#popupPollInterval = null;
+		}
+		if (this.#popupTimeoutHandle !== null) {
+			clearTimeout(this.#popupTimeoutHandle);
+			this.#popupTimeoutHandle = null;
+		}
+		if (this.#popupMessageListener !== null) {
+			window.removeEventListener('message', this.#popupMessageListener);
+			this.#popupMessageListener = null;
+		}
+		this.#popupAuthOperation = null;
+	}
+
+	async signInViaPopup(
+		config: ICatalystPopupSignInConfig = {}
+	): Promise<ICatalystPopupSignInResult> {
+		if (this.#popupAuthOperation && this.#popupAuthOperation.status === 'waiting') {
+			throw new CatalystAuthenticationError(
+				'POPUP_ALREADY_OPEN',
+				'A sign-in popup is already open.'
+			);
+		}
+		const width = config.width ?? POPUP_DEFAULT_WIDTH;
+		const height = config.height ?? POPUP_DEFAULT_HEIGHT;
+		const timeoutMs = config.timeoutMs ?? POPUP_DEFAULT_TIMEOUT_MS;
+		const eventId = createPopupEventId();
+
+		return new Promise<ICatalystPopupSignInResult>((resolve, reject) => {
+			const onMessage = async (event: MessageEvent): Promise<void> => {
+				if (!this.#popupAuthOperation || this.#popupAuthOperation.status !== 'waiting') {
+					return;
+				}
+				if (event.origin !== window.location.origin || !event.data) {
+					return;
+				}
+				if (event.data.type === POPUP_MSG_AUTH_ERROR) {
+					this.#clearPopupOperation('cancelled');
+					reject(
+						new CatalystAuthenticationError(
+							'POPUP_AUTH_ERROR',
+							event.data.message ?? 'Sign-in failed.'
+						)
+					);
+					return;
+				}
+				if (event.data.type !== POPUP_MSG_AUTH_TOKEN) {
+					return;
+				}
+				if (event.data.eventId !== this.#popupAuthOperation.eventId) {
+					return;
+				}
+
+				const accessToken = event.data.access_token;
+				if (typeof accessToken !== 'string' || !accessToken || accessToken.length > 1000) {
+					this.#clearPopupOperation('cancelled');
+					reject(
+						new CatalystAuthenticationError(
+							'INVALID_TOKEN',
+							'Popup sent missing or malformed token.'
+						)
+					);
+					return;
+				}
+
+				try {
+					const expiresInSec =
+						typeof event.data.expires_in_sec === 'number' &&
+						isFinite(event.data.expires_in_sec) &&
+						event.data.expires_in_sec > 0 &&
+						event.data.expires_in_sec < 86400 * 30
+							? event.data.expires_in_sec
+							: 3600;
+					this.#popupAuthOperation.status = 'completed';
+					const expiresAt = await this.#setTokenStorage(accessToken, expiresInSec);
+					this.#setAuthProtocol(Auth_Protocol.OAuthTokenProtocol);
+					this.#clearPopupOperation('completed');
+					resolve({
+						access_token: accessToken,
+						expires_at: expiresAt,
+						event_id: eventId
+					});
+				} catch (err) {
+					this.#clearPopupOperation('cancelled');
+					reject(
+						new CatalystAuthenticationError(
+							'POST_AUTH_ERROR',
+							err instanceof Error ? err.message : String(err)
+						)
+					);
+				}
+			};
+
+			this.#popupMessageListener = onMessage;
+			window.addEventListener('message', onMessage);
+
+			const popup = openPopupWindow({
+				url: buildPopupLoginUrl(window.location.origin, eventId),
+				name: 'catalystSignIn',
+				width,
+				height
+			});
+			this.#popupAuthOperation = { eventId, status: 'waiting', popup, createdAt: Date.now() };
+
+			this.#popupPollInterval = setInterval(() => {
+				if (!this.#popupAuthOperation || this.#popupAuthOperation.status !== 'waiting') {
+					this.#clearPopupOperation('cancelled');
+					return;
+				}
+				if (this.#popupAuthOperation.popup?.closed) {
+					this.#clearPopupOperation('cancelled');
+					reject(
+						new CatalystAuthenticationError(
+							'POPUP_CLOSED',
+							'Popup closed before auth completed.'
+						)
+					);
+					return;
+				}
+				try {
+					this.#popupAuthOperation.popup?.postMessage(
+						{ type: POPUP_MSG_AUTH_REQUEST, eventId: this.#popupAuthOperation.eventId },
+						window.location.origin
+					);
+				} catch {
+					// suppress during cross-origin redirects
+				}
+			}, POPUP_POLL_INTERVAL_MS);
+
+			this.#popupTimeoutHandle = setTimeout(() => {
+				if (this.#popupAuthOperation?.status === 'waiting') {
+					this.#clearPopupOperation('expired');
+					reject(
+						new CatalystAuthenticationError(
+							'POPUP_TIMEOUT',
+							`Popup timed out after ${timeoutMs / 1000}s.`
+						)
+					);
+				}
+			}, timeoutMs);
+		});
+	}
+
+	async signOutViaPopup(redirectUrl = '/'): Promise<void> {
+		const popup = openPopupWindow({
+			url: buildPopupLogoutUrl(window.location.origin),
+			name: 'catalystSignOut',
+			width: POPUP_DEFAULT_WIDTH,
+			height: POPUP_DEFAULT_HEIGHT
+		});
+		return new Promise<void>((resolve, reject) => {
+			const timeoutHandle = setTimeout(() => {
+				window.removeEventListener('message', onMessage);
+				try {
+					if (!popup.closed) {
+						popup.close();
+					}
+				} catch {
+					// ignore close errors
+				}
+				reject(new CatalystAuthenticationError('POPUP_TIMEOUT', 'Sign-out timed out.'));
+			}, POPUP_DEFAULT_TIMEOUT_MS);
+
+			const onMessage = async (event: MessageEvent): Promise<void> => {
+				if (event.origin !== window.location.origin) {
+					return;
+				}
+				if (!event.data || event.data.type !== POPUP_MSG_SIGNOUT_DONE) {
+					return;
+				}
+				clearTimeout(timeoutHandle);
+				window.removeEventListener('message', onMessage);
+				try {
+					if (!popup.closed) {
+						popup.close();
+					}
+				} catch {
+					// ignore close errors
+				}
+				await this.#clearTokenStorage();
+				document.cookie = `user_cred=; max-age=0; path=/`;
+				if (redirectUrl) {
+					window.location.replace(redirectUrl);
+				}
+				resolve();
+			};
+
+			window.addEventListener('message', onMessage);
+		});
 	}
 }
 export { UserManagement } from './user-management';

--- a/packages/auth/src/web.ts
+++ b/packages/auth/src/web.ts
@@ -191,6 +191,16 @@ class Authentication implements Component {
 	 * ```
 	 */
 	async signIn(id: string, config: ICatalystSignInConfig = {}): Promise<void> {
+		// Ensure credentials are loaded before using projectId/zaid.
+		// If init() was not called, or if the constructor's fire-and-forget
+		// getCredentials() hasn't finished yet, this guarantees they are ready.
+		if (!ConfigStore.get('INITIALIZED')) {
+			await getCredentials();
+			this.zaid = ConfigStore.get('ZAID') as string;
+			this.projectId = ConfigStore.get('PROJECT_ID') as string;
+			this.isAppsail = ConfigStore.get('IS_APPSAIL') as string;
+			this.authProtocol = ConfigStore.get('AUTH_PROTOCOL') as unknown as Auth_Protocol;
+		}
 		if (detectIframeContext()) {
 			await this.signInViaPopup({
 				width: config.popupWidth,

--- a/packages/transport/jest.config.js
+++ b/packages/transport/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   ...base,
   moduleNameMapper: {
     "^@zcatalyst/auth-admin$": "../../auth-admin/src/__mocks__",
+    "^@zcatalyst/auth-client$": "<rootDir>/../../packages/auth-client/src",
   },
   coverageThreshold: {
     global: {

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zcatalyst/transport",
-  "version": "0.0.3",
+  "version": "0.0.3-beta-login",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
@@ -44,7 +44,7 @@
   "dependencies": {
     "@zcatalyst/auth-admin": "workspace:^",
     "@zcatalyst/utils": "workspace:^",
-    "@zcatalyst/auth-client": "workspace:^"
+    "@zcatalyst/auth-client": "workspace:*"
   },
   "browser": {
     "./dist-cjs/index.js": "./dist-cjs/index.browser.js",

--- a/packages/transport/src/fetch-handler.ts
+++ b/packages/transport/src/fetch-handler.ts
@@ -1,10 +1,13 @@
 import {
 	addDefaultAppHeaders,
 	Auth_Protocol,
+	clearOAuthTokenFromIDB,
 	collectZCRFToken,
 	ConfigStore,
+	getOAuthTokenFromIDB,
 	getToken,
 	JWT_COOKIE_PREFIX,
+	OAUTH_TOKEN_PREFIX,
 	PROJECT_ID
 } from '@zcatalyst/auth-client';
 import { CatalystService, CONSTANTS, getServicePath } from '@zcatalyst/utils';
@@ -337,6 +340,8 @@ export class ResponseHandler {
 				return await ResponseHandler.#followZcrfTokenProtocol(headers);
 			case Auth_Protocol.JwtTokenProtocol:
 				return await ResponseHandler.#followJwtZCAuthProtocol(headers);
+			case Auth_Protocol.OAuthTokenProtocol:
+				return await ResponseHandler.#followOAuthTokenProtocol(headers);
 			default:
 				return Promise.resolve(headers);
 		}
@@ -363,6 +368,18 @@ export class ResponseHandler {
 			});
 	}
 
+	static async #followOAuthTokenProtocol(headers: HeadersInit): Promise<HeadersInit> {
+		return this.getOAuthZCAuthToken()
+			.then((resp) => {
+				(headers as Record<string, string>)[HTTP_HEADER_MAP.AUTHORIZATION_KEY] =
+					resp.access_token;
+				return headers;
+			})
+			.catch((err) => {
+				throw new CatalystAPIError('API_ERROR', err.message, err.status);
+			});
+	}
+
 	// Method to get JWT authentication token
 	/**
 	 * Builds the browser JWT authorization token from the configured cookie.
@@ -378,7 +395,7 @@ export class ResponseHandler {
 	public static getJWTZCAuthToken(): Promise<jwtAccessTokenResponse> {
 		const jwtPrefix = ConfigStore.get(JWT_COOKIE_PREFIX);
 		return new Promise((resolve, reject) => {
-			const jwtZCAuthToken = getToken() as unknown as string;
+			const jwtZCAuthToken = getToken(JWT_COOKIE_PREFIX) as unknown as string;
 			if (jwtZCAuthToken === '') {
 				reject('Unable to get the JWT Access Token.');
 			} else {
@@ -387,6 +404,20 @@ export class ResponseHandler {
 				});
 			}
 		});
+	}
+
+	public static async getOAuthZCAuthToken(): Promise<jwtAccessTokenResponse> {
+		const stored = await getOAuthTokenFromIDB();
+		if (!stored?.token) {
+			throw new Error('No access token found.');
+		}
+		if (stored.exp <= Date.now()) {
+			await clearOAuthTokenFromIDB();
+			throw new Error('Access token has expired.');
+		}
+		return {
+			access_token: `${OAUTH_TOKEN_PREFIX} ${stored.token}`
+		};
 	}
 
 	/**

--- a/packages/transport/tests/handler.test.ts
+++ b/packages/transport/tests/handler.test.ts
@@ -1,8 +1,113 @@
+import { Auth_Protocol, ConfigStore } from '@zcatalyst/auth-client';
+
 import { Handler } from '../src';
+import { ResponseHandler } from '../src/fetch-handler';
 import { RequestType, ResponseType } from '../src/utils/enums';
 import { IRequestConfig } from '../src/utils/interfaces';
 
 describe('Handler', () => {
+	const idbStore = new Map();
+	const sessionStore = new Map<string, string>();
+
+	function setupSessionStorageMock() {
+		const sessionStorageMock = {
+			getItem: (key: string) => (sessionStore.has(key) ? sessionStore.get(key)! : null),
+			setItem: (key: string, value: string) => {
+				sessionStore.set(key, value);
+			},
+			removeItem: (key: string) => {
+				sessionStore.delete(key);
+			},
+			clear: () => {
+				sessionStore.clear();
+			},
+			key: (index: number) => Array.from(sessionStore.keys())[index] ?? null,
+			get length() {
+				return sessionStore.size;
+			}
+		};
+
+		(globalThis as any).sessionStorage = sessionStorageMock;
+	}
+
+	function setupIndexedDBMock() {
+		(global as unknown as { indexedDB: unknown }).indexedDB = {
+			open: jest.fn(() => {
+				const request: any = {
+					result: {
+						objectStoreNames: {
+							contains: () => true
+						},
+						createObjectStore: jest.fn(),
+						transaction: () => {
+							const transaction: any = {};
+							const store = {
+								get: (key: string) => {
+									const idbRequest: any = {};
+									queueMicrotask(() => {
+										idbRequest.result = idbStore.get(key);
+										idbRequest.onsuccess?.(new Event('success'));
+										transaction.oncomplete?.(new Event('complete'));
+									});
+									return idbRequest;
+								},
+								put: (value: unknown, key: string) => {
+									const idbRequest: any = {};
+									queueMicrotask(() => {
+										idbStore.set(key, value);
+										idbRequest.result = undefined;
+										idbRequest.onsuccess?.(new Event('success'));
+										transaction.oncomplete?.(new Event('complete'));
+									});
+									return idbRequest;
+								},
+								delete: (key: string) => {
+									const idbRequest: any = {};
+									queueMicrotask(() => {
+										idbStore.delete(key);
+										idbRequest.result = undefined;
+										idbRequest.onsuccess?.(new Event('success'));
+										transaction.oncomplete?.(new Event('complete'));
+									});
+									return idbRequest;
+								}
+							};
+							return {
+								objectStore: () => store,
+								set oncomplete(handler: unknown) {
+									transaction.oncomplete = handler;
+								},
+								get oncomplete() {
+									return transaction.oncomplete;
+								},
+								set onerror(handler: unknown) {
+									transaction.onerror = handler;
+								},
+								get onerror() {
+									return transaction.onerror;
+								},
+								error: null
+							};
+						},
+						close: jest.fn()
+					}
+				};
+				queueMicrotask(() => {
+					request.onsuccess?.(new Event('success'));
+				});
+				return request;
+			})
+		};
+	}
+
+	beforeEach(() => {
+		setupSessionStorageMock();
+		ConfigStore.clear();
+		sessionStore.clear();
+		idbStore.clear();
+		setupIndexedDBMock();
+	});
+
 	describe('request configuration', () => {
 		it('should handle JSON request type', () => {
 			const config: IRequestConfig = {
@@ -77,6 +182,99 @@ describe('Handler', () => {
 			};
 
 			expect(config.expecting).toBe(ResponseType.RAW);
+		});
+	});
+
+	describe('OAuth auth headers', () => {
+		it('should attach Zoho OAuth token from IndexedDB', async () => {
+			ConfigStore.set('AUTH_PROTOCOL', Auth_Protocol.OAuthTokenProtocol);
+			idbStore.set('zcatalyst_client_token', {
+				token: 'oauth-token',
+				exp: Date.now() + 60_000
+			});
+
+			const headers = (await ResponseHandler.attachZCAuthHeaders({})) as Record<
+				string,
+				string
+			>;
+
+			expect(headers.Authorization).toBe('Zoho-oauthtoken oauth-token');
+		});
+
+		it('should return headers unchanged when auth protocol is not set', async () => {
+			ConfigStore.clear();
+			const headers = (await ResponseHandler.attachZCAuthHeaders({
+				Accept: 'application/json'
+			})) as Record<string, string>;
+
+			expect(headers.Accept).toBe('application/json');
+			expect(headers.Authorization).toBeUndefined();
+		});
+
+		it('should reject when OAuth token is missing', async () => {
+			await expect(ResponseHandler.getOAuthZCAuthToken()).rejects.toThrow(
+				'No access token found.'
+			);
+		});
+
+		it('should reject when OAuth token is expired', async () => {
+			idbStore.set('zcatalyst_client_token', {
+				token: 'oauth-token',
+				exp: Date.now() - 1000
+			});
+
+			await expect(ResponseHandler.getOAuthZCAuthToken()).rejects.toThrow(
+				'Access token has expired.'
+			);
+			expect(idbStore.has('zcatalyst_client_token')).toBe(false);
+		});
+
+		it('should attach Bearer token for legacy JWT protocol', async () => {
+			(globalThis as any).document = {
+				cookie: 'JWT_AUTH=jwt-token'
+			};
+			ConfigStore.set('AUTH_PROTOCOL', Auth_Protocol.JwtTokenProtocol);
+			ConfigStore.set('JWT_AUTH', 'Bearer');
+
+			const headers = (await ResponseHandler.attachZCAuthHeaders({})) as Record<
+				string,
+				string
+			>;
+
+			expect(headers.Authorization).toBe('Bearer jwt-token');
+		});
+	});
+
+	describe('appendQueryString', () => {
+		it('should preserve existing params when appending query strings', () => {
+			const result = ResponseHandler.appendQueryString('/path?existing=1', {
+				added: '2'
+			});
+
+			expect(result).toBe('/path?existing=1&added=2');
+		});
+
+		it('should return url unchanged when no query params are provided', () => {
+			expect(ResponseHandler.appendQueryString('/path')).toBe('/path');
+		});
+	});
+
+	describe('wrapResponse', () => {
+		it('should avoid parsing body for no-content responses', async () => {
+			const response = {
+				status: 204,
+				headers: {},
+				json: jest.fn(),
+				text: jest.fn(),
+				blob: jest.fn(),
+				arrayBuffer: jest.fn()
+			} as unknown as Response;
+
+			const wrapped = await ResponseHandler.wrapResponse(response, {
+				request: { method: 'GET' }
+			});
+
+			expect(wrapped.data).toBe('');
 		});
 	});
 });

--- a/packages/transport/tests/setup.ts
+++ b/packages/transport/tests/setup.ts
@@ -30,3 +30,32 @@ jest.mock('../src/http-handler', () => {
 afterEach(() => {
 	jest.clearAllMocks();
 });
+
+const sessionStore = new Map<string, string>();
+
+const mockSessionStorage = {
+	getItem: (key: string) => (sessionStore.has(key) ? sessionStore.get(key)! : null),
+	setItem: (key: string, value: string) => {
+		sessionStore.set(key, value);
+	},
+	removeItem: (key: string) => {
+		sessionStore.delete(key);
+	},
+	clear: () => {
+		sessionStore.clear();
+	},
+	key: (index: number) => Array.from(sessionStore.keys())[index] ?? null,
+	get length() {
+		return sessionStore.size;
+	}
+};
+
+Object.defineProperty(global, 'sessionStorage', {
+	value: mockSessionStorage,
+	writable: true
+});
+
+Object.defineProperty(globalThis, 'sessionStorage', {
+	value: mockSessionStorage,
+	writable: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,10 +97,10 @@ importers:
         specifier: workspace:^
         version: link:../auth-admin
       '@zcatalyst/auth-client':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../auth-client
       '@zcatalyst/transport':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../transport
       '@zcatalyst/utils':
         specifier: workspace:^
@@ -297,7 +297,7 @@ importers:
         specifier: workspace:^
         version: link:../auth-admin
       '@zcatalyst/auth-client':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../auth-client
       '@zcatalyst/utils':
         specifier: workspace:^


### PR DESCRIPTION
### Description

**What does this implement/fix? Explain your changes.**

#### feat(auth): Add Sign-In via Popup with OAuthTokenProtocol and IDB storage

Implements a new popup-based authentication flow for the Catalyst browser SDK. This is needed for iframe-hosted apps where a nested login iframe is blocked by the browser's sandbox policy.

**`packages/auth-client`**
- Added `src/utils/idb-token.ts` — IndexedDB helpers (`setOAuthTokenInIDB`, `getOAuthTokenFromIDB`, `clearOAuthTokenFromIDB`) to persist OAuth access tokens across popup page loads
- Re-exported IDB token helpers from the package index

**`packages/auth` — `src/web.ts`**
- `signInViaPopup(config?)` — Opens a controlled popup to `/__catalyst/auth/login/popup/{eventId}`, polls via `postMessage`, resolves with `{ access_token, expires_at, event_id }`. Handles timeout, popup-closed, and error cases
- `signOutViaPopup(redirectUrl?)` — Opens popup to `/__catalyst/auth/logout/popup`, listens for `catalyst-signout-done` message, clears token and redirects
- `isIframeContext()` — Detects if the SDK is running inside an iframe; `signIn()` auto-delegates to `signInViaPopup()` when inside an iframe
- `deliverAuthTokenToParent(config?)` — Called from the popup login page to post the OAuth token back to the opener
- `deliverSignOutDoneToParent(config?)` — Called from the popup logout page to notify the opener
- `generateAuthToken(feature)` — Mints an OAuth token via `/authentication/custom-token` -> `/clientoauth/v2/{zaid}/remote/auth`
- `popupConstants` — Exported popup path and message-type string constants
- `#setTokenStorage()` — Persists token in IDB + schedules proactive refresh 5 minutes before expiry to avoid mid-session token expiry
- `#clearTokenStorage()` — Clears IDB token and cancels the refresh timer
- `isHosted` option added to popup config

**`packages/transport`**
- Updated `fetch-handler.ts` to support `origin` override and `auth: false` options needed by the remote token exchange request

---

#### fix(auth): Ensure credentials are loaded before `signIn()` even without `init()` call

Added an `!ConfigStore.get('INITIALIZED')` guard at the top of `signIn()`. If `init()` was never called, it awaits `getCredentials()` before using `projectId`/`zaid`, preventing `portal=undefined` in the IAM iframe URL.

Also fixed `signIn()` to default the redirect target to `window.location.pathname + window.location.search` instead of an empty string, and to redirect back to that path after popup auth completes.

---

#### fix(auth): `init()` was an empty no-op — now awaits credentials

`init()` previously did nothing (`async init(): Promise<void> {}`). It now:
- `await getCredentials()` — waits for `/sdk/init` to fully resolve
- Re-reads `zaid`, `projectId`, `isAppsail`, `authProtocol` from `ConfigStore` into instance fields after resolution
- Checks IDB for a stored OAuth token and activates `OAuthTokenProtocol` if found and still valid

---

#### fix: Handle multiple parallel calls triggering race condition (`packages/auth-client`)

Introduced a module-level `_credentialsPromise: Promise<void> | null` sentinel in `getCredentials()`. All concurrent callers (e.g. constructor fire-and-forget + explicit `await zcAuth.init()`) share the same in-flight Promise — only ONE `/sdk/init` request is made:

Before:
  constructor   -> getCredentials() -> fetch /sdk/init  (Promise #1)
  zcAuth.init() -> getCredentials() -> fetch /sdk/init  (Promise #2 — race!)
  -> second caller reads projectId = undefined mid-fetch

After:
  constructor   -> getCredentials() -> fetch /sdk/init  (Promise #1)
  zcAuth.init() -> _credentialsPromise !== null -> returns Promise #1
  -> both callers wait on ONE fetch

- On failure -> promise cleared in `catch` so next caller retries fresh
- On success -> promise cleared in `finally` so re-init after sign-out works

---

### Testing

- Added `packages/auth-client/tests/index.test.ts` — tests for concurrent `getCredentials()` calls sharing one promise, failure reset, and normal credential population
- Added `packages/transport/tests/handler.test.ts` — transport handler tests for `origin` override and `auth: false` options
- Manual verification:
  - GET /__catalyst/sdk/init -> 200 OK
  - GET /baas/v1/project/undefined/... -> no longer occurs after fix
  - GET /baas/v1/project/{projectId}/project-user/current -> 200 OK
  - Popup sign-in resolves with token
  - Popup closed early -> rejects with POPUP_CLOSED error
  - Popup timeout -> rejects with POPUP_TIMEOUT error
  - signIn() inside iframe -> auto-delegates to signInViaPopup()
  - Concurrent getCredentials() -> only one /sdk/init request in Network tab
  - Token auto-refresh fires 5 minutes before expiry

---

### Additional context

- The `_credentialsPromise` race fix is the foundational fix — without it the popup page itself hits `project/undefined` because it calls `init()` while the constructor's fire-and-forget is still in-flight
- `deliverAuthTokenToParent` and `deliverSignOutDoneToParent` are intended ONLY for the Catalyst-served popup pages at `/__catalyst/auth/login/popup` and `/__catalyst/auth/logout/popup`
- The proactive token refresh timer (5 min before expiry) prevents silent auth failures mid-session without any user interaction

---

### Checklist
- [ ] I have read and agree to the Contributor License Agreement (CLA) (../CONTRIBUTOR_LICENCE_AGREEMENT.txt)
- [ ] The PR title follows the format: `<type><scope>:<description><prid(#123)>`

Your PR will not be merged unless the CLA is signed.
